### PR TITLE
add a --with-toolset=xxx command-line parameter to bootstrap.bat

### DIFF
--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -5,6 +5,13 @@ REM
 REM Distributed under the Boost Software License, Version 1.0.
 REM (See accompanying file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
 
+REM Process command-line arguments, if any
+call :process-args %*
+if %ERRORLEVEL% NEQ 0 goto :eof
+
+if "%TOOLSET%"=="" (
+    set TOOLSET=msvc)
+
 ECHO Building Boost.Build engine
 if exist ".\tools\build\v2\engine\bin.ntx86\b2.exe" del tools\build\v2\engine\bin.ntx86\b2.exe
 if exist ".\tools\build\v2\engine\bin.ntx86\bjam.exe" del tools\build\v2\engine\bin.ntx86\bjam.exe
@@ -12,7 +19,7 @@ if exist ".\tools\build\v2\engine\bin.ntx86_64\b2.exe" del tools\build\v2\engine
 if exist ".\tools\build\v2\engine\bin.ntx86_64\bjam.exe" del tools\build\v2\engine\bin.ntx86_64\bjam.exe
 pushd tools\build\v2\engine
 
-call .\build.bat %* > ..\..\..\..\bootstrap.log
+call .\build.bat %TOOLSET% > ..\..\..\..\bootstrap.log
 @ECHO OFF
 
 popd
@@ -31,15 +38,9 @@ goto :bjam_failure
 
 :bjam_built
 
-REM Ideally, we should obtain the toolset that build.bat has
-REM guessed. However, it uses setlocal at the start and does
-REM export BOOST_JAM_TOOLSET, and I don't know how to do that
-REM properly. Default to msvc for now.
-set toolset=msvc
-
 ECHO import option ; > project-config.jam
 ECHO. >> project-config.jam
-ECHO using %toolset% ; >> project-config.jam
+ECHO using %TOOLSET% ; >> project-config.jam
 ECHO. >> project-config.jam
 ECHO option.set keep-going : false ; >> project-config.jam
 ECHO. >> project-config.jam
@@ -61,7 +62,7 @@ ECHO.
 ECHO     - Boost.Build documentation:
 ECHO     http://www.boost.org/boost-build2/doc/html/index.html
 
-goto :end
+goto :eof
 
 :bjam_failure
 
@@ -76,6 +77,15 @@ ECHO.
 ECHO Also, you can file an issue at http://svn.boost.org 
 ECHO Please attach bootstrap.log in that case.
 
-goto :end
+goto :eof
 
-:end
+:process-args
+if "%~1"=="" exit /b 0
+if "%1"=="--with-toolset" (
+    if "%2"=="" (
+        echo ERROR: Expecting the name of a toolset
+        exit /b 1)
+    set TOOLSET=%2
+    shift
+    shift)
+goto :process-args


### PR DESCRIPTION
per the "bootstrap.bat broken for MinGW since 1.55" thread on boost-devel.
