### PR TITLE
Fix nits with linux-user-config.jam

### DIFF
--- a/tools/release/linux_user-config.jam
+++ b/tools/release/linux_user-config.jam
@@ -4,7 +4,8 @@ import toolset : using ;
 
 using gcc ;
 
-using python ; # requires pythonN.NN-dev be installed
+# Uncomment if project-config.jam does not already have this.
+#using python ; # requires pythonN.NN-dev be installed
 
 # Boost iostreams requires no user-config.jam entries,
 # but does require zlib1g-dev, libbz2-dev, be installed


### PR DESCRIPTION
The python issue bit me; the misspelled package is a drive-by.
