### PR TITLE
Add missing Boost.Log target, boost_log_setup.

### DIFF
--- a/Jamroot
+++ b/Jamroot
@@ -238,6 +238,9 @@ for local l in $(all-libraries)
     }
 }
 
+# Log has an additional target
+explicit-alias log_setup : libs/log/build//boost_log_setup ;
+
 alias headers : $(all-headers)-headers numeric-$(numeric-headers)-headers : : : <include>.  ;
 explicit headers ;
 


### PR DESCRIPTION
In addition to the boost_log target, Boost.Log also has a boost_log_setup library that is sometimes needed. Added the target to the top level Jamroot so it is available when using Boost.Build as your build tool.
