### PR TITLE
Remove expected failure for Boost.Log on gcc 4.2

### DIFF
--- a/status/explicit-failures-markup.xml
+++ b/status/explicit-failures-markup.xml
@@ -2573,14 +2573,6 @@
 	<!-- log -->
 	<library name="log">
 		<mark-unusable>
-			<toolset name="darwin-4.2*"/>
-			<toolset name="gcc-4.2*"/>
-			<note author="Andrey Semashev" date="02 May 2013">
-				These compilers don't support TR1 result_of correctly, which makes them fail
-				to compile Boost.Phoenix-related code of the library.
-			</note>
-		</mark-unusable>
-		<mark-unusable>
 			<toolset name="vacpp-12.1*"/>
 			<note author="Andrey Semashev" date="02 May 2013">
 				The compiler fails to compile Boost.Move and Boost.PropertyTree, which are used by this library.


### PR DESCRIPTION
According to an email from John Fletcher, removed expected failure for Boost.Log on gcc 4.2 caused by Boost.Phoenix.
