### PR TITLE
optional refs can't work on qcc 4.4.*

### DIFF
--- a/status/explicit-failures-markup.xml
+++ b/status/explicit-failures-markup.xml
@@ -2996,6 +2996,8 @@ for more information.
             <toolset name="gcc-4.3*"/>
             <toolset name="gcc-4.4*"/>
             <toolset name="gcc-4.5*"/>
+            <toolset name="qcc-4.4.2_arm"/>
+            <toolset name="qcc-4.4.2_x86"/>
                 <note author="Fernando Cacciola" id="optional-compiler-bug">
                 <p>This failure is caused by a compiler bug, and as far as we can 
                 tell, can't be worked around in the library, although we think 


### PR DESCRIPTION
This is caused by a compiler bug, which cannot be worked around. A similar bug to the one in gcc 4.4 series.
