### PR TITLE
Fixed relative path of child libraries to be /boostorg/*. 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,484 +1,484 @@
 [submodule "system"]
 	path = libs/system
-	url = ../system.git
+	url = ../../boostorg/system.git
 	fetchRecurseSubmodules = on-demand
 [submodule "multi_array"]
 	path = libs/multi_array
-	url = ../multi_array.git
+	url = ../../boostorg/multi_array.git
 	fetchRecurseSubmodules = on-demand
 [submodule "math"]
 	path = libs/math
-	url = ../math.git
+	url = ../../boostorg/math.git
 	fetchRecurseSubmodules = on-demand
 [submodule "smart_ptr"]
 	path = libs/smart_ptr
-	url = ../smart_ptr.git
+	url = ../../boostorg/smart_ptr.git
 	fetchRecurseSubmodules = on-demand
 [submodule "parameter"]
 	path = libs/parameter
-	url = ../parameter.git
+	url = ../../boostorg/parameter.git
 	fetchRecurseSubmodules = on-demand
 [submodule "algorithm"]
 	path = libs/algorithm
-	url = ../algorithm.git
+	url = ../../boostorg/algorithm.git
 	fetchRecurseSubmodules = on-demand
 [submodule "any"]
 	path = libs/any
-	url = ../any.git
+	url = ../../boostorg/any.git
 	fetchRecurseSubmodules = on-demand
 [submodule "concept_check"]
 	path = libs/concept_check
-	url = ../concept_check.git
+	url = ../../boostorg/concept_check.git
 	fetchRecurseSubmodules = on-demand
 [submodule "python"]
 	path = libs/python
-	url = ../python.git
+	url = ../../boostorg/python.git
 	fetchRecurseSubmodules = on-demand
 [submodule "tti"]
 	path = libs/tti
-	url = ../tti.git
+	url = ../../boostorg/tti.git
 	fetchRecurseSubmodules = on-demand
 [submodule "functional"]
 	path = libs/functional
-	url = ../functional.git
+	url = ../../boostorg/functional.git
 	fetchRecurseSubmodules = on-demand
 [submodule "config"]
 	path = libs/config
-	url = ../config.git
+	url = ../../boostorg/config.git
 	fetchRecurseSubmodules = on-demand
 [submodule "log"]
 	path = libs/log
-	url = ../log.git
+	url = ../../boostorg/log.git
 	fetchRecurseSubmodules = on-demand
 [submodule "interprocess"]
 	path = libs/interprocess
-	url = ../interprocess.git
+	url = ../../boostorg/interprocess.git
 	fetchRecurseSubmodules = on-demand
 [submodule "exception"]
 	path = libs/exception
-	url = ../exception.git
+	url = ../../boostorg/exception.git
 	fetchRecurseSubmodules = on-demand
 [submodule "foreach"]
 	path = libs/foreach
-	url = ../foreach.git
+	url = ../../boostorg/foreach.git
 	fetchRecurseSubmodules = on-demand
 [submodule "spirit"]
 	path = libs/spirit
-	url = ../spirit.git
+	url = ../../boostorg/spirit.git
 	fetchRecurseSubmodules = on-demand
 [submodule "io"]
 	path = libs/io
-	url = ../io.git
+	url = ../../boostorg/io.git
 	fetchRecurseSubmodules = on-demand
 [submodule "disjoint_sets"]
 	path = libs/disjoint_sets
-	url = ../disjoint_sets.git
+	url = ../../boostorg/disjoint_sets.git
 	fetchRecurseSubmodules = on-demand
 [submodule "units"]
 	path = libs/units
-	url = ../units.git
+	url = ../../boostorg/units.git
 	fetchRecurseSubmodules = on-demand
 [submodule "preprocessor"]
 	path = libs/preprocessor
-	url = ../preprocessor.git
+	url = ../../boostorg/preprocessor.git
 	fetchRecurseSubmodules = on-demand
 [submodule "format"]
 	path = libs/format
-	url = ../format.git
+	url = ../../boostorg/format.git
 	fetchRecurseSubmodules = on-demand
 [submodule "xpressive"]
 	path = libs/xpressive
-	url = ../xpressive.git
+	url = ../../boostorg/xpressive.git
 	fetchRecurseSubmodules = on-demand
 [submodule "integer"]
 	path = libs/integer
-	url = ../integer.git
+	url = ../../boostorg/integer.git
 	fetchRecurseSubmodules = on-demand
 [submodule "thread"]
 	path = libs/thread
-	url = ../thread.git
+	url = ../../boostorg/thread.git
 	fetchRecurseSubmodules = on-demand
 [submodule "tokenizer"]
 	path = libs/tokenizer
-	url = ../tokenizer.git
+	url = ../../boostorg/tokenizer.git
 	fetchRecurseSubmodules = on-demand
 [submodule "timer"]
 	path = libs/timer
-	url = ../timer.git
+	url = ../../boostorg/timer.git
 	fetchRecurseSubmodules = on-demand
 [submodule "inspect"]
 	path = tools/inspect
-	url = ../inspect.git
+	url = ../../boostorg/inspect.git
 	fetchRecurseSubmodules = on-demand
 [submodule "boostbook"]
 	path = tools/boostbook
-	url = ../boostbook.git
+	url = ../../boostorg/boostbook.git
 	fetchRecurseSubmodules = on-demand
 [submodule "regex"]
 	path = libs/regex
-	url = ../regex.git
+	url = ../../boostorg/regex.git
 	fetchRecurseSubmodules = on-demand
 [submodule "crc"]
 	path = libs/crc
-	url = ../crc.git
+	url = ../../boostorg/crc.git
 	fetchRecurseSubmodules = on-demand
 [submodule "random"]
 	path = libs/random
-	url = ../random.git
+	url = ../../boostorg/random.git
 	fetchRecurseSubmodules = on-demand
 [submodule "serialization"]
 	path = libs/serialization
-	url = ../serialization.git
+	url = ../../boostorg/serialization.git
 	fetchRecurseSubmodules = on-demand
 [submodule "test"]
 	path = libs/test
-	url = ../test.git
+	url = ../../boostorg/test.git
 	fetchRecurseSubmodules = on-demand
 [submodule "date_time"]
 	path = libs/date_time
-	url = ../date_time.git
+	url = ../../boostorg/date_time.git
 	fetchRecurseSubmodules = on-demand
 [submodule "logic"]
 	path = libs/logic
-	url = ../logic.git
+	url = ../../boostorg/logic.git
 	fetchRecurseSubmodules = on-demand
 [submodule "graph"]
 	path = libs/graph
-	url = ../graph.git
+	url = ../../boostorg/graph.git
 	fetchRecurseSubmodules = on-demand
 [submodule "numeric_conversion"]
 	path = libs/numeric/conversion
-	url = ../numeric_conversion.git
+	url = ../../boostorg/numeric_conversion.git
 	fetchRecurseSubmodules = on-demand
 [submodule "lambda"]
 	path = libs/lambda
-	url = ../lambda.git
+	url = ../../boostorg/lambda.git
 	fetchRecurseSubmodules = on-demand
 [submodule "mpl"]
 	path = libs/mpl
-	url = ../mpl.git
+	url = ../../boostorg/mpl.git
 	fetchRecurseSubmodules = on-demand
 [submodule "typeof"]
 	path = libs/typeof
-	url = ../typeof.git
+	url = ../../boostorg/typeof.git
 	fetchRecurseSubmodules = on-demand
 [submodule "tuple"]
 	path = libs/tuple
-	url = ../tuple.git
+	url = ../../boostorg/tuple.git
 	fetchRecurseSubmodules = on-demand
 [submodule "utility"]
 	path = libs/utility
-	url = ../utility.git
+	url = ../../boostorg/utility.git
 	fetchRecurseSubmodules = on-demand
 [submodule "dynamic_bitset"]
 	path = libs/dynamic_bitset
-	url = ../dynamic_bitset.git
+	url = ../../boostorg/dynamic_bitset.git
 	fetchRecurseSubmodules = on-demand
 [submodule "assign"]
 	path = libs/assign
-	url = ../assign.git
+	url = ../../boostorg/assign.git
 	fetchRecurseSubmodules = on-demand
 [submodule "filesystem"]
 	path = libs/filesystem
-	url = ../filesystem.git
+	url = ../../boostorg/filesystem.git
 	fetchRecurseSubmodules = on-demand
 [submodule "function"]
 	path = libs/function
-	url = ../function.git
+	url = ../../boostorg/function.git
 	fetchRecurseSubmodules = on-demand
 [submodule "conversion"]
 	path = libs/conversion
-	url = ../conversion.git
+	url = ../../boostorg/conversion.git
 	fetchRecurseSubmodules = on-demand
 [submodule "optional"]
 	path = libs/optional
-	url = ../optional.git
+	url = ../../boostorg/optional.git
 	fetchRecurseSubmodules = on-demand
 [submodule "property_tree"]
 	path = libs/property_tree
-	url = ../property_tree.git
+	url = ../../boostorg/property_tree.git
 	fetchRecurseSubmodules = on-demand
 [submodule "bimap"]
 	path = libs/bimap
-	url = ../bimap.git
+	url = ../../boostorg/bimap.git
 	fetchRecurseSubmodules = on-demand
 [submodule "variant"]
 	path = libs/variant
-	url = ../variant.git
+	url = ../../boostorg/variant.git
 	fetchRecurseSubmodules = on-demand
 [submodule "array"]
 	path = libs/array
-	url = ../array.git
+	url = ../../boostorg/array.git
 	fetchRecurseSubmodules = on-demand
 [submodule "iostreams"]
 	path = libs/iostreams
-	url = ../iostreams.git
+	url = ../../boostorg/iostreams.git
 	fetchRecurseSubmodules = on-demand
 [submodule "multi_index"]
 	path = libs/multi_index
-	url = ../multi_index.git
+	url = ../../boostorg/multi_index.git
 	fetchRecurseSubmodules = on-demand
 [submodule "bcp"]
 	path = tools/bcp
-	url = ../bcp.git
+	url = ../../boostorg/bcp.git
 	fetchRecurseSubmodules = on-demand
 [submodule "ptr_container"]
 	path = libs/ptr_container
-	url = ../ptr_container.git
+	url = ../../boostorg/ptr_container.git
 	fetchRecurseSubmodules = on-demand
 [submodule "statechart"]
 	path = libs/statechart
-	url = ../statechart.git
+	url = ../../boostorg/statechart.git
 	fetchRecurseSubmodules = on-demand
 [submodule "static_assert"]
 	path = libs/static_assert
-	url = ../static_assert.git
+	url = ../../boostorg/static_assert.git
 	fetchRecurseSubmodules = on-demand
 [submodule "range"]
 	path = libs/range
-	url = ../range.git
+	url = ../../boostorg/range.git
 	fetchRecurseSubmodules = on-demand
 [submodule "signals"]
 	path = libs/signals
-	url = ../signals.git
+	url = ../../boostorg/signals.git
 	fetchRecurseSubmodules = on-demand
 [submodule "rational"]
 	path = libs/rational
-	url = ../rational.git
+	url = ../../boostorg/rational.git
 	fetchRecurseSubmodules = on-demand
 [submodule "tr1"]
 	path = libs/tr1
-	url = ../tr1.git
+	url = ../../boostorg/tr1.git
 	fetchRecurseSubmodules = on-demand
 [submodule "iterator"]
 	path = libs/iterator
-	url = ../iterator.git
+	url = ../../boostorg/iterator.git
 	fetchRecurseSubmodules = on-demand
 [submodule "build"]
 	path = tools/build
-	url = ../build.git
+	url = ../../boostorg/build.git
 	fetchRecurseSubmodules = on-demand
 [submodule "quickbook"]
 	path = tools/quickbook
-	url = ../quickbook.git
+	url = ../../boostorg/quickbook.git
 	fetchRecurseSubmodules = on-demand
 [submodule "graph_parallel"]
 	path = libs/graph_parallel
-	url = ../graph_parallel.git
+	url = ../../boostorg/graph_parallel.git
 	fetchRecurseSubmodules = on-demand
 [submodule "property_map"]
 	path = libs/property_map
-	url = ../property_map.git
+	url = ../../boostorg/property_map.git
 	fetchRecurseSubmodules = on-demand
 [submodule "program_options"]
 	path = libs/program_options
-	url = ../program_options.git
+	url = ../../boostorg/program_options.git
 	fetchRecurseSubmodules = on-demand
 [submodule "detail"]
 	path = libs/detail
-	url = ../detail.git
+	url = ../../boostorg/detail.git
 	fetchRecurseSubmodules = on-demand
 [submodule "interval"]
 	path = libs/numeric/interval
-	url = ../interval.git
+	url = ../../boostorg/interval.git
 	fetchRecurseSubmodules = on-demand
 [submodule "ublas"]
 	path = libs/numeric/ublas
-	url = ../ublas.git
+	url = ../../boostorg/ublas.git
 	fetchRecurseSubmodules = on-demand
 [submodule "wave"]
 	path = libs/wave
-	url = ../wave.git
+	url = ../../boostorg/wave.git
 	fetchRecurseSubmodules = on-demand
 [submodule "type_traits"]
 	path = libs/type_traits
-	url = ../type_traits.git
+	url = ../../boostorg/type_traits.git
 	fetchRecurseSubmodules = on-demand
 [submodule "compatibility"]
 	path = libs/compatibility
-	url = ../compatibility.git
+	url = ../../boostorg/compatibility.git
 	fetchRecurseSubmodules = on-demand
 [submodule "bind"]
 	path = libs/bind
-	url = ../bind.git
+	url = ../../boostorg/bind.git
 	fetchRecurseSubmodules = on-demand
 [submodule "pool"]
 	path = libs/pool
-	url = ../pool.git
+	url = ../../boostorg/pool.git
 	fetchRecurseSubmodules = on-demand
 [submodule "proto"]
 	path = libs/proto
-	url = ../proto.git
+	url = ../../boostorg/proto.git
 	fetchRecurseSubmodules = on-demand
 [submodule "fusion"]
 	path = libs/fusion
-	url = ../fusion.git
+	url = ../../boostorg/fusion.git
 	fetchRecurseSubmodules = on-demand
 [submodule "function_types"]
 	path = libs/function_types
-	url = ../function_types.git
+	url = ../../boostorg/function_types.git
 	fetchRecurseSubmodules = on-demand
 [submodule "gil"]
 	path = libs/gil
-	url = ../gil.git
+	url = ../../boostorg/gil.git
 	fetchRecurseSubmodules = on-demand
 [submodule "intrusive"]
 	path = libs/intrusive
-	url = ../intrusive.git
+	url = ../../boostorg/intrusive.git
 	fetchRecurseSubmodules = on-demand
 [submodule "asio"]
 	path = libs/asio
-	url = ../asio.git
+	url = ../../boostorg/asio.git
 	fetchRecurseSubmodules = on-demand
 [submodule "uuid"]
 	path = libs/uuid
-	url = ../uuid.git
+	url = ../../boostorg/uuid.git
 	fetchRecurseSubmodules = on-demand
 [submodule "litre"]
 	path = tools/litre
-	url = ../litre.git
+	url = ../../boostorg/litre.git
 	fetchRecurseSubmodules = on-demand
 [submodule "circular_buffer"]
 	path = libs/circular_buffer
-	url = ../circular_buffer.git
+	url = ../../boostorg/circular_buffer.git
 	fetchRecurseSubmodules = on-demand
 [submodule "mpi"]
 	path = libs/mpi
-	url = ../mpi.git
+	url = ../../boostorg/mpi.git
 	fetchRecurseSubmodules = on-demand
 [submodule "unordered"]
 	path = libs/unordered
-	url = ../unordered.git
+	url = ../../boostorg/unordered.git
 	fetchRecurseSubmodules = on-demand
 [submodule "signals2"]
 	path = libs/signals2
-	url = ../signals2.git
+	url = ../../boostorg/signals2.git
 	fetchRecurseSubmodules = on-demand
 [submodule "accumulators"]
 	path = libs/accumulators
-	url = ../accumulators.git
+	url = ../../boostorg/accumulators.git
 	fetchRecurseSubmodules = on-demand
 [submodule "atomic"]
 	path = libs/atomic
-	url = ../atomic.git
+	url = ../../boostorg/atomic.git
 	fetchRecurseSubmodules = on-demand
 [submodule "scope_exit"]
 	path = libs/scope_exit
-	url = ../scope_exit.git
+	url = ../../boostorg/scope_exit.git
 	fetchRecurseSubmodules = on-demand
 [submodule "flyweight"]
 	path = libs/flyweight
-	url = ../flyweight.git
+	url = ../../boostorg/flyweight.git
 	fetchRecurseSubmodules = on-demand
 [submodule "icl"]
 	path = libs/icl
-	url = ../icl.git
+	url = ../../boostorg/icl.git
 	fetchRecurseSubmodules = on-demand
 [submodule "predef"]
 	path = libs/predef
-	url = ../predef.git
+	url = ../../boostorg/predef.git
 	fetchRecurseSubmodules = on-demand
 [submodule "chrono"]
 	path = libs/chrono
-	url = ../chrono.git
+	url = ../../boostorg/chrono.git
 	fetchRecurseSubmodules = on-demand
 [submodule "polygon"]
 	path = libs/polygon
-	url = ../polygon.git
+	url = ../../boostorg/polygon.git
 	fetchRecurseSubmodules = on-demand
 [submodule "msm"]
 	path = libs/msm
-	url = ../msm.git
+	url = ../../boostorg/msm.git
 	fetchRecurseSubmodules = on-demand
 [submodule "heap"]
 	path = libs/heap
-	url = ../heap.git
+	url = ../../boostorg/heap.git
 	fetchRecurseSubmodules = on-demand
 [submodule "coroutine"]
 	path = libs/coroutine
-	url = ../coroutine.git
+	url = ../../boostorg/coroutine.git
 	fetchRecurseSubmodules = on-demand
 [submodule "ratio"]
 	path = libs/ratio
-	url = ../ratio.git
+	url = ../../boostorg/ratio.git
 	fetchRecurseSubmodules = on-demand
 [submodule "odeint"]
 	path = libs/numeric/odeint
-	url = ../odeint.git
+	url = ../../boostorg/odeint.git
 	fetchRecurseSubmodules = on-demand
 [submodule "geometry"]
 	path = libs/geometry
-	url = ../geometry.git
+	url = ../../boostorg/geometry.git
 	fetchRecurseSubmodules = on-demand
 [submodule "phoenix"]
 	path = libs/phoenix
-	url = ../phoenix.git
+	url = ../../boostorg/phoenix.git
 	fetchRecurseSubmodules = on-demand
 [submodule "move"]
 	path = libs/move
-	url = ../move.git
+	url = ../../boostorg/move.git
 	fetchRecurseSubmodules = on-demand
 [submodule "locale"]
 	path = libs/locale
-	url = ../locale.git
+	url = ../../boostorg/locale.git
 	fetchRecurseSubmodules = on-demand
 [submodule "auto_index"]
 	path = tools/auto_index
-	url = ../auto_index.git
+	url = ../../boostorg/auto_index.git
 	fetchRecurseSubmodules = on-demand
 [submodule "container"]
 	path = libs/container
-	url = ../container.git
+	url = ../../boostorg/container.git
 	fetchRecurseSubmodules = on-demand
 [submodule "local_function"]
 	path = libs/local_function
-	url = ../local_function.git
+	url = ../../boostorg/local_function.git
 	fetchRecurseSubmodules = on-demand
 [submodule "context"]
 	path = libs/context
-	url = ../context.git
+	url = ../../boostorg/context.git
 	fetchRecurseSubmodules = on-demand
 [submodule "type_erasure"]
 	path = libs/type_erasure
-	url = ../type_erasure.git
+	url = ../../boostorg/type_erasure.git
 	fetchRecurseSubmodules = on-demand
 [submodule "multiprecision"]
 	path = libs/multiprecision
-	url = ../multiprecision.git
+	url = ../../boostorg/multiprecision.git
 	fetchRecurseSubmodules = on-demand
 [submodule "lockfree"]
 	path = libs/lockfree
-	url = ../lockfree.git
+	url = ../../boostorg/lockfree.git
 	fetchRecurseSubmodules = on-demand
 [submodule "assert"]
 	path = libs/assert
-	url = ../assert.git
+	url = ../../boostorg/assert.git
 	fetchRecurseSubmodules = on-demand
 [submodule "align"]
 	path = libs/align
-	url = ../align.git
+	url = ../../boostorg/align.git
 	fetchRecurseSubmodules = on-demand
 [submodule "type_index"]
 	path = libs/type_index
-	url = ../type_index.git
+	url = ../../boostorg/type_index.git
 	fetchRecurseSubmodules = on-demand
 [submodule "core"]
 	path = libs/core
-	url = ../core.git
+	url = ../../boostorg/core.git
 	fetchRecurseSubmodules = on-demand
 [submodule "throw_exception"]
 	path = libs/throw_exception
-	url = ../throw_exception.git
+	url = ../../boostorg/throw_exception.git
 	fetchRecurseSubmodules = on-demand
 [submodule "winapi"]
 	path = libs/winapi
-	url = ../winapi.git
+	url = ../../boostorg/winapi.git
 	fetchRecurseSubmodules = on-demand
 [submodule "boostdep"]
 	path = tools/boostdep
-	url = ../boostdep.git
+	url = ../../boostorg/boostdep.git
 	fetchRecurseSubmodules = on-demand
 [submodule "lexical_cast"]
 	path = libs/lexical_cast
-	url = ../lexical_cast.git
+	url = ../../boostorg/lexical_cast.git
 	fetchRecurseSubmodules = on-demand


### PR DESCRIPTION
Forked super project boost expects child sub-projects to be located in parent directory. This requires forking every single sub-project.Instead it should point to 'home' directory of the repository /boostorg/*. 
