### PR TITLE
Added files 'b2.exe' and 'bjam.exe' to ignore list on windows platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /b2
+/b2.exe
 /bin.v2
 /bjam
+/bjam.exe
 /bootstrap.log
 /boost
 /dist


### PR DESCRIPTION
Building toolset on Windows platform adds two *.exe files to boost directory and makes repository dirty. Added these two files to ignore list.