### PR TITLE
Make sure all headers are installed before build

### DIFF
--- a/tools/regression/build/Jamroot.jam
+++ b/tools/regression/build/Jamroot.jam
@@ -1,4 +1,3 @@
-# Regression test status reporting tools build Jamfile
 
 # Copyright Rene Rivera
 
@@ -16,20 +15,23 @@ else
     use-project /boost : [ MATCH --boost=(.*) : [ modules.peek : ARGV ] ] ;
 }
 
+local source_location ;
 if ! [ glob ../src/process_jam_log.cpp ]
 {
-    project boost/regression
-        :
-        source-location ..
-        ;
+    source_location = .. ;
 }
 else
 {
-    project boost/regression
-        :
-        source-location ../src
-        ;
+    source_location = ../src ;
 }
+
+project boost/regression
+    :
+    source-location $(source_location)
+    :
+    requirements
+        <dependency>/boost//headers
+    ;
 
 obj tiny_xml
     :
@@ -37,7 +39,6 @@ obj tiny_xml
     :
     <define>BOOST_ALL_NO_LIB=1
     <define>_CRT_SECURE_NO_WARNINGS
-    <implicit-dependency>/boost//headers
     :
     release
     ;
@@ -51,7 +52,6 @@ exe process_jam_log
     :
     <define>BOOST_ALL_NO_LIB=1
     <define>_CRT_SECURE_NO_WARNINGS
-    <implicit-dependency>/boost//headers
     :
     release
     ;
@@ -64,7 +64,6 @@ exe compiler_status
     /boost/filesystem//boost_filesystem/<link>static
     :
     <define>BOOST_ALL_NO_LIB=1
-    <implicit-dependency>/boost//headers
     :
     release
     ;
@@ -77,7 +76,6 @@ exe library_status
     /boost/filesystem//boost_filesystem/<link>static
     :
     <define>BOOST_ALL_NO_LIB=1
-    <implicit-dependency>/boost//headers
     :
     release
     ;
@@ -94,7 +92,6 @@ exe boost_report
     /boost//iostreams/<link>static
     :
     <define>BOOST_ALL_NO_LIB=1
-    <implicit-dependency>/boost//headers
     :
     release
     ;

--- a/tools/regression/build/Jamroot.jam
+++ b/tools/regression/build/Jamroot.jam
@@ -1,9 +1,10 @@
+# Regression test status reporting tools build Jamfile
 
 # Copyright Rene Rivera
 
 # Distributed under the Boost Software License, Version 1.0.
 # See http://www.boost.org/LICENSE_1_0.txt
- 
+
 
 if [ glob ../../../boost-build.jam ]
 {


### PR DESCRIPTION
Add /boost//headers as a common dependency for all testing tools. The implicit dependency that was used before didn't work:

http://boost.2283326.n4.nabble.com/testing-mpl-core-tests-not-visible-tt4667495.html#a4667510
