### PR TITLE
Update expected failures for MSVC

### DIFF
--- a/status/explicit-failures-markup.xml
+++ b/status/explicit-failures-markup.xml
@@ -685,6 +685,7 @@
                 <toolset name="msvc-10.0*"/>
                 <toolset name="msvc-11.0*"/>
                 <toolset name="msvc-12.0*"/>
+                <toolset name="msvc-14.0*"/>
                 <toolset name="msvc-7.1*"/>
                 <toolset name="vacpp-10.1"/>
                 <toolset name="qcc-4*"/>
@@ -2137,6 +2138,7 @@
 			<toolset name="msvc-10.0*"/>
 			<toolset name="msvc-11.0*"/>
 			<toolset name="msvc-12.0*"/>
+			<toolset name="msvc-14.0*"/>
 			<note author="Joachim Faulhaber">
 				Compiler error expected for msvc: A minimal example of a class template 'value' that
 				results in syntax error in a subsequent meta function.


### PR DESCRIPTION
The tests that are incompatible with the C++11 auto keyword and promote_enum_msvc_bug_test also fail on all newer versions of MSVC.
