### PR TITLE
Add sort/test to status/Jamfile.v2

### DIFF
--- a/status/Jamfile.v2
+++ b/status/Jamfile.v2
@@ -151,6 +151,7 @@ run-tests libs :
     signals/test                # test-suite signals
     signals2/test               # test-suite signals2
     smart_ptr/test              # test-suite smart_ptr
+    sort/test                   # test-suite sort
     spirit/classic/test         # test-suite classic spirit
     spirit/test                 # test-suite spirit_v2
     spirit/repository/test      # test-suite spirit_v2 repository


### PR DESCRIPTION
This will enabling testing of the new sort library.

The sort library is here: https://github.com/boostorg/sort.  Do I also need to add it directly to this boost project in some fashion?