### PR TITLE
Add sort to libraries.html

### DIFF
--- a/libs/libraries.htm
+++ b/libs/libraries.htm
@@ -308,6 +308,8 @@ how to download, build, and install the libraries.</p>
     <li><a href="smart_ptr/index.html">smart_ptr</a> - Six smart
         pointer class templates, from Greg Colvin, Beman Dawes,
         Peter Dimov, Darin Adler, and Glen Fernandes.</li>
+    <li><a href="sort/index.html">sort</a> - library that includes spreadsort, a general-case
+        hybrid radix sort that is faster than O(n*log(n))</li>
     <li><a href="statechart/doc/index.html">statechart</a> - Arbitrarily
     complex finite state machines can be implemented in easily readable and
     maintainable C++ code, from Andreas Huber.</li>
@@ -401,6 +403,8 @@ how to download, build, and install the libraries.</p>
     <li><a href="range/index.html">range</a> - A new infrastructure
         for generic algorithms that builds on top
         of the new iterator concepts, from Thorsten Ottosen.</li>
+    <li><a href="sort/index.html">sort</a> - library that includes spreadsort, a general-case
+        hybrid radix sort that is faster than O(n*log(n))</li>
     <li><a href="algorithm/string/index.html">string_algo</a> -
         String algorithms library, from Pavol Droba</li>
     <li><a href="utility/utility.htm">utility</a> - Class <b>next(),</b>&nbsp; <b>prior()</b>


### PR DESCRIPTION
I assume the qbk documentation that this links into will be built automatically in a master release.  Algorithms seems like the appropriate category for the new sort library.