### PR TITLE
Remove references to removed regression directory

### DIFF
--- a/tools/Jamfile.v2
+++ b/tools/Jamfile.v2
@@ -17,15 +17,10 @@ project
     usage-requirements <implicit-dependency>/boost//headers 
     ;
 
-use-project /boost/regression : regression/build ;
-
 TOOLS =
     bcp//bcp
     inspect/build//inspect
     quickbook//quickbook
-    /boost/regression//compiler_status
-    /boost/regression//library_status
-    /boost/regression//process_jam_log
     /boost/libs/wave/tool//wave
     ;
 


### PR DESCRIPTION
The directory tools/regression was removed. So remove the references to it.
Or add the new regression repository as a submodule.