### PR TITLE
Update explicit-failures-markup.xml

### DIFF
--- a/status/explicit-failures-markup.xml
+++ b/status/explicit-failures-markup.xml
@@ -716,8 +716,11 @@
             <mark-failure>
                 <toolset name="vacpp-*"/>
                 <toolset name="vacpp"/>
+                <toolset name="msvc-8.0"/>
+                <toolset name="msvc-9.0"/>
                 <toolset name="msvc-9.0~stlport5.2"/>
                 <toolset name="msvc-9.0~wm5~stlport5.2"/>
+                <toolset name="msvc-10.0"/>
                 <toolset name="intel-darwin-11.*"/>
                 <toolset name="intel-darwin-12.0"/>
                 <toolset name="qcc-4*"/>


### PR DESCRIPTION
Some of the strict tests of lexical_cast are failing after falling back to compiler specific float types conversion (refs [svn 10639](https://svn.boost.org/trac/boost/ticket/10639)).