### PR TITLE
Add the boost_log_setup target to the top level Jamroot

### DIFF
--- a/Jamroot
+++ b/Jamroot
@@ -226,6 +226,9 @@ for local l in $(all-libraries)
     }
 }
 
+# Log has an additional target
+explicit-alias log_setup : libs/log/build//boost_log_setup ;
+
 alias headers : $(all-headers)-headers : : : <include>.  ;
 explicit headers ;
 


### PR DESCRIPTION
Boost.Log has a boost_log_setup library target that is sometimes needed. Add the target to the top level Jamroot so it is available when using Boost.Build as your build tool.