### PR TITLE
Update expected failures for MSVC14

### DIFF
--- a/status/explicit-failures-markup.xml
+++ b/status/explicit-failures-markup.xml
@@ -700,7 +700,6 @@
                 <toolset name="msvc-10.0*"/>
                 <toolset name="msvc-11.0*"/>
                 <toolset name="msvc-12.0*"/>
-                <toolset name="msvc-14.0*"/>
                 <toolset name="msvc-7.1*"/>
                 <toolset name="vacpp-10.1"/>
                 <toolset name="qcc-4*"/>


### PR DESCRIPTION
Since CTP 5, lexical_cast_loopback_test passes on MSVC14:
http://www.boost.org/development/tests/develop/developer/output/teeks99-08f-win2012R2-64on64-boost-bin-v2-libs-lexical_cast-test-lexical_cast_loopback_test-test-msvc-14-0-dbg-adrs-mdl-64-lnk-sttc-thrd-mlt.html