### PR TITLE
set sharedlib version on aix when aix-soname=svr4

### DIFF
--- a/boostcpp.jam
+++ b/boostcpp.jam
@@ -153,7 +153,8 @@ rule tag ( name : type ? : property-set )
         # libFoo.1.2.3.dylib format. AIX linkers do not accept version suffixes
         # either. Pgi compilers can not accept a library with version suffix.
         if $(type) = SHARED_LIB &&
-          ! [ $(property-set).get <target-os> ] in windows cygwin darwin aix &&
+          ( ! [ $(property-set).get <target-os> ] in windows cygwin darwin aix ||
+            ( [ $(property-set).get <target-os> ] in aix && [ $(property-set).get <aix-soname> ] = svr4 ) ) &&
           ! [ $(property-set).get <toolset> ] in pgi
         {
             result = $(result).$(BOOST_VERSION)  ;


### PR DESCRIPTION
This patch is to actually set the sharedlib version for filename-based shared library versioning on AIX from https://github.com/boostorg/build/pull/70
