### PR TITLE
Update ICL failures for MSVC14

### DIFF
--- a/status/explicit-failures-markup.xml
+++ b/status/explicit-failures-markup.xml
@@ -2177,7 +2177,6 @@
 			<toolset name="msvc-10.0*"/>
 			<toolset name="msvc-11.0*"/>
 			<toolset name="msvc-12.0*"/>
-			<toolset name="msvc-14.0*"/>
 			<note author="Joachim Faulhaber">
 				Compiler error expected for msvc: A minimal example of a class template 'value' that
 				results in syntax error in a subsequent meta function.


### PR DESCRIPTION
This test finally passes with MSVC 14 RTM.