### PR TITLE
Add Hana as a submodule of the master repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -517,3 +517,6 @@
 [submodule "libs/metaparse"]
 	path = libs/metaparse
 	url = ../metaparse.git
+[submodule "libs/hana"]
+	path = libs/hana
+	url = ../hana.git

--- a/libs/libraries.htm
+++ b/libs/libraries.htm
@@ -178,6 +178,9 @@ how to download, build, and install the libraries.</p>
     <li><a href="graph/doc/table_of_contents.html">graph</a> -
         Generic graph components and algorithms, from Jeremy Siek
         and a University of Notre Dame team; now maintained by Andrew Sutton and Jeremiah Willcock.</li>
+    <li><a href="hana/doc/html/index.html">hana</a> (C++14) - Heterogeneous sequences
+    and algorithms, type-level computations and other metaprogramming tools,
+    from Louis Dionne</li>
     <li><a href="heap/index.html">heap</a> -
         Priority queue data structures, from Tim Blechmann</li>
     <li><a href="icl/index.html">icl</a> -
@@ -796,6 +799,9 @@ of arbitrary data for persistence and marshalling, from Robert Ramey</li>
     <li><a href="fusion/index.html">fusion</a> -
         Library for working with tuples, including various containers,
     algorithms, etc. From Joel de Guzman, Dan Marsden and Tobias Schwinger.</li>
+    <li><a href="hana/doc/html/index.html">hana</a> (C++14) - Heterogeneous sequences
+    and algorithms, type-level computations and other metaprogramming tools,
+    from Louis Dionne</li>
     <li><a href="metaparse/index.html">metaparse</a> - A library for generating
     compile time parsers parsing embedded DSL code as part of the C++
     compilation process, from &Aacute;bel Sinkovics.</li>

--- a/libs/maintainers.txt
+++ b/libs/maintainers.txt
@@ -57,6 +57,7 @@ fusion                Joel de Guzman <joel -at- boost-consulting.com>, Dan Marsd
 geometry              Barend Gehrels <barend -at- xs4all.nl>, Bruno Lalande <bruno.lalande -at- gmail.com>, Mateusz Loskot <mateusz -at- loskot.net>, Adam Wulkiewicz <adam.wulkiewicz -at- gmail.com>
 gil                   Christian Henning <chhenning -at- gmail.com>
 graph                 Andrew Sutton <asutton -at- cs.kent.edu>
+hana                  Louis Dionne <ldionne.2 -at- gmail.com>
 heap                  Tim Blechmann <tim -at- klingt.org>
 icl                   Joachim Faulhaber <afojgo -at- gmail.com>
 integer               Daryle Walker <darylew -at- hotmail.com>

--- a/status/Jamfile.v2
+++ b/status/Jamfile.v2
@@ -100,6 +100,7 @@ run-tests libs :
     gil/test                    # test-suite gil
     graph/test                  # test-suite graph
     graph_parallel/test         # test-suite graph/parallel
+    hana/test                   # test-suite hana
     heap/test                   # test-suite heap
     icl/test                    # test-suite icl
     integer/test                # test-suite integer


### PR DESCRIPTION
Specifically:
- Adds Hana's test suite to the regression tests
- Add Hana as the libs/hana submodule
- Add entry for Hana to libs/maintainers.txt and libs/libraries.htm

__NOTE__
This is not ready to be merged yet! I want to see the Travis results so I can adjust some things before this is ready.
