### PR TITLE
[Travis] Run on the container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: c
 compiler:
   - gcc


### PR DESCRIPTION
Title is self-explanatory. I don't think there's any reason to still use Travis' legacy infrastructure.