### PR TITLE
(master branch) Add Hana as a submodule of the master repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -506,3 +506,6 @@
 	path = libs/compute
 	url = ../compute.git
 	fetchRecurseSubmodules = on-demand
+[submodule "libs/hana"]
+	path = libs/hana
+	url = ../hana.git

--- a/libs/libraries.htm
+++ b/libs/libraries.htm
@@ -174,6 +174,9 @@ how to download, build, and install the libraries.</p>
     <li><a href="graph/doc/table_of_contents.html">graph</a> -
         Generic graph components and algorithms, from Jeremy Siek
         and a University of Notre Dame team; now maintained by Andrew Sutton and Jeremiah Willcock.</li>
+    <li><a href="hana/doc/html/index.html">hana</a> (C++14) - Heterogeneous sequences
+    and algorithms, type-level computations and other metaprogramming tools,
+    from Louis Dionne</li>
     <li><a href="heap/index.html">heap</a> -
         Priority queue data structures, from Tim Blechmann</li>
     <li><a href="icl/index.html">icl</a> -
@@ -787,6 +790,9 @@ of arbitrary data for persistence and marshalling, from Robert Ramey</li>
     <li><a href="fusion/index.html">fusion</a> -
         Library for working with tuples, including various containers,
     algorithms, etc. From Joel de Guzman, Dan Marsden and Tobias Schwinger.</li>
+    <li><a href="hana/doc/html/index.html">hana</a> (C++14) - Heterogeneous sequences
+    and algorithms, type-level computations and other metaprogramming tools,
+    from Louis Dionne</li>
     <li><a href="mpl/doc/index.html">mpl</a> - Template metaprogramming
     framework of compile-time algorithms, sequences and metafunction classes,
     from Aleksey Gurtovoy.</li>

--- a/libs/maintainers.txt
+++ b/libs/maintainers.txt
@@ -56,6 +56,7 @@ fusion                Joel de Guzman <joel -at- boost-consulting.com>, Dan Marsd
 geometry              Barend Gehrels <barend -at- xs4all.nl>, Bruno Lalande <bruno.lalande -at- gmail.com>, Mateusz Loskot <mateusz -at- loskot.net>, Adam Wulkiewicz <adam.wulkiewicz -at- gmail.com>
 gil                   Christian Henning <chhenning -at- gmail.com>
 graph                 Andrew Sutton <asutton -at- cs.kent.edu>
+hana                  Louis Dionne <ldionne.2 -at- gmail.com>
 heap                  Tim Blechmann <tim -at- klingt.org>
 icl                   Joachim Faulhaber <afojgo -at- gmail.com>
 integer               Daryle Walker <darylew -at- hotmail.com>

--- a/status/Jamfile.v2
+++ b/status/Jamfile.v2
@@ -97,6 +97,7 @@ run-tests libs :
     gil/test                    # test-suite gil
     graph/test                  # test-suite graph
     graph_parallel/test         # test-suite graph/parallel
+    hana/test                   # test-suite hana
     heap/test                   # test-suite heap
     icl/test                    # test-suite icl
     integer/test                # test-suite integer


### PR DESCRIPTION
This PR is equivalent to https://github.com/boostorg/boost/pull/98, except it targets the master branch instead of the develop branch of the modularized Boost repository.

From my understanding, merging this PR will cause Hana to be included in the next release of Boost. Please do not merge this PR yet; I need to resolve some issues in Hana before it is fully ready to ship with the next version of Boost.