### PR TITLE
getting started: Do no longer mention experimental CMake build

### DIFF
--- a/more/getting_started/unix-variants.html
+++ b/more/getting_started/unix-variants.html
@@ -306,11 +306,6 @@ need to use <a class="reference external" href="../../tools/build/index.html">Bo
 <p>You'll also
 use this method if you need a nonstandard build variant (see the
 <a class="reference external" href="../../tools/build/index.html">Boost.Build documentation</a> for more details).</p>
-<div class="admonition-boost-cmake admonition">
-<p class="first admonition-title">Boost.CMake</p>
-<p class="last">There is also an experimental CMake build for boost, supported and distributed
-separately.  See the <a class="reference external" href="https://svn.boost.org/trac/boost/wiki/CMake">Boost.CMake</a> wiki page for more information.</p>
-</div>
 <!-- Copyright David Abrahams 2006. Distributed under the Boost -->
 <!-- Software License, Version 1.0. (See accompanying -->
 <!-- file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt) -->

--- a/more/getting_started/unix-variants.rst
+++ b/more/getting_started/unix-variants.rst
@@ -135,14 +135,6 @@ You'll also
 use this method if you need a nonstandard build variant (see the
 `Boost.Build documentation`_ for more details).
 
-.. Admonition:: Boost.CMake
-
-  There is also an experimental CMake build for boost, supported and distributed
-  separately.  See the `Boost.CMake`_ wiki page for more information.
-
-  .. _`Boost.CMake`:
-       https://svn.boost.org/trac/boost/wiki/CMake
-
 .. include:: detail/build-from-source-head.rst
 
 For example, your session might look like this:

--- a/more/getting_started/windows.html
+++ b/more/getting_started/windows.html
@@ -365,11 +365,6 @@ of allowed options.</p>
 <p>If you're using an earlier version of Visual C++, or a compiler
 from another vendor, you'll need to use <a class="reference external" href="../../tools/build/index.html">Boost.Build</a> to create your
 own binaries.</p>
-<div class="admonition-boost-cmake admonition">
-<p class="first admonition-title">Boost.CMake</p>
-<p class="last">There is also an experimental CMake build for boost, supported and distributed
-separately.  See the <a class="reference external" href="https://svn.boost.org/trac/boost/wiki/CMake">Boost.CMake</a> wiki page for more information.</p>
-</div>
 <!-- Copyright David Abrahams 2006. Distributed under the Boost -->
 <!-- Software License, Version 1.0. (See accompanying -->
 <!-- file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt) -->

--- a/more/getting_started/windows.rst
+++ b/more/getting_started/windows.rst
@@ -192,14 +192,6 @@ If you're using an earlier version of Visual C++, or a compiler
 from another vendor, you'll need to use Boost.Build_ to create your
 own binaries.
 
-.. Admonition:: Boost.CMake
-
-  There is also an experimental CMake build for boost, supported and distributed
-  separately.  See the `Boost.CMake`_ wiki page for more information.
-
-  .. _`Boost.CMake`:
-       https://svn.boost.org/trac/boost/wiki/CMake
-
 .. include:: detail/build-from-source-head.rst
 
 For example, your session might look like this: [#continuation]_


### PR DESCRIPTION
The linked wiki page is outdated, the project seems to be dead. If
it is still active, update link to new page.