### PR TITLE
Update address in maintainers.txt

### DIFF
--- a/libs/maintainers.txt
+++ b/libs/maintainers.txt
@@ -114,7 +114,7 @@ serialization         Robert Ramey <ramey -at- rrsd.com>
 signals               Douglas Gregor <dgregor -at- cs.indiana.edu>
 signals2              Frank Mori Hess <fmhess -at- users.sourceforge.net>
 smart_ptr             Peter Dimov <pdimov -at- pdimov.com>
-smart_ptr/make_shared Glen Fernandes <glenfe -at- live.com>
+smart_ptr/make_shared Glen Fernandes <glenjofe -at- gmail.com>
 sort                  Steven Ross <spreadsort -at- gmail.com>
 spirit                Joel de Guzman <joel -at- boost-consulting.com>, Hartmut Kaiser <hartmut.kaiser -at- gmail.com>
 statechart            Andreas Huber <ahd6974-boostorg -at- yahoo.com>


### PR DESCRIPTION
Use the same e-mail address as listed in maintainers.txt for the Core library.