### PR TITLE
Add stacktrace library to master branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -530,3 +530,7 @@
 	path = libs/process
 	url = ../process.git
 	fetchRecurseSubmodules = on-demand
+[submodule "stacktrace"]
+	path = libs/stacktrace
+	url = ../stacktrace.git
+	fetchRecurseSubmodules = on-demand

--- a/libs/maintainers.txt
+++ b/libs/maintainers.txt
@@ -118,6 +118,7 @@ smart_ptr             Peter Dimov <pdimov -at- pdimov.com>
 smart_ptr/make_shared Glen Fernandes <glenfe -at- live.com>
 sort                  Steven Ross <spreadsort -at- gmail.com>
 spirit                Joel de Guzman <joel -at- boost-consulting.com>, Hartmut Kaiser <hartmut.kaiser -at- gmail.com>
+stacktrace            Antony Polukhin <antoshkka -at- gmail.com>
 statechart            Andreas Huber <ahd6974-boostorg -at- yahoo.com>
 static_assert         John Maddock <john -at- johnmaddock.co.uk>
 test                  Gennadiy Rozental <rogeeff -at- gmail.com>, Raffi Enficiaud <raffi.enficiaud -at- free.fr>

--- a/libs/maintainers.txt
+++ b/libs/maintainers.txt
@@ -118,7 +118,6 @@ smart_ptr             Peter Dimov <pdimov -at- pdimov.com>
 smart_ptr/make_shared Glen Fernandes <glenfe -at- live.com>
 sort                  Steven Ross <spreadsort -at- gmail.com>
 spirit                Joel de Guzman <joel -at- boost-consulting.com>, Hartmut Kaiser <hartmut.kaiser -at- gmail.com>
-stacktrace            Antony Polukhin <antoshkka -at- gmail.com>
 statechart            Andreas Huber <ahd6974-boostorg -at- yahoo.com>
 static_assert         John Maddock <john -at- johnmaddock.co.uk>
 test                  Gennadiy Rozental <rogeeff -at- gmail.com>, Raffi Enficiaud <raffi.enficiaud -at- free.fr>


### PR DESCRIPTION
Works well on MSVC, GCC, intel and clang compilers.
Known MinGW problem does not seem to be show stopper.