### PR TITLE
Fix stage target to not use undefined BOOST_STAGE_LOCATE

### DIFF
--- a/Jamroot
+++ b/Jamroot
@@ -134,6 +134,7 @@ import virtual-target ;
 import "class" : new ;
 import property-set ;
 import threadapi-feature ;
+import option ;
 
 path-constant BOOST_ROOT : . ;
 constant BOOST_VERSION : 1.66.0 ;
@@ -299,7 +300,9 @@ rule boost-install ( libraries * )
         : # No headers, it is handled by the dependency.
     ;
 
-    install stage : $(libraries) : <location>$(BOOST_STAGE_LOCATE) ;
+    local stage-locate = [ option.get stagedir : $(BOOST_ROOT)/stage ] ;
+
+    install stage : $(libraries) : <location>$(stage-locate)/lib ;
 
     module [ CALLER_MODULE ]
     {


### PR DESCRIPTION
`BOOST_STAGE_LOCATE` is undefined in `boost-install`, so it always uses the target name, `stage`. This means that when `b2 stage` is invoked from, f.ex. `libs/system/build`, a local `libs/system/build/stage` directory is used for staging. This is almost certainly wrong. In addition, `BOOST_STAGE_LOCATE` in `boostcpp` is by default the relative path `stage`, so even if used with `modules.peek`, it works the same way.

I'm not entirely sure that the proposed replacement is correct in all use cases, but it's an improvement. :-)