### PR TITLE
Add <address-model> to versioned tag

### DIFF
--- a/boostcpp.jam
+++ b/boostcpp.jam
@@ -123,7 +123,7 @@ rule tag ( name : type ? : property-set )
         if $(layout) = versioned
         {
             result = [ common.format-name
-                <base> <toolset> <threading> <runtime> -$(BOOST_VERSION_TAG)
+                <base> <toolset> <threading> <runtime> <address-model> -$(BOOST_VERSION_TAG)
                 -$(BUILD_ID)
                 : $(name) : $(type) : $(property-set) ] ;
         }


### PR DESCRIPTION
This requires a corresponding change to Config autolink, boostorg/config#159.

I'm not sure if the tagged layout also needs the address model or not; I've left it untouched for now.