### PR TITLE
Remove <threading>single from --build-type=complete

### DIFF
--- a/boostcpp.jam
+++ b/boostcpp.jam
@@ -372,7 +372,7 @@ class top-level-target : alias-target-class
 
         self.complete-properties = [ property-set.create
             <variant>debug <variant>release
-            <threading>single <threading>multi
+            <threading>multi
             <link>shared <link>static
             <runtime-link>shared <runtime-link>static ] ;
     }


### PR DESCRIPTION
As a data point, the last MSVC version with a single-threaded runtime is 7.1 (2003). I don't think there's a need to keep building this configuration.