### PR TITLE
Encode architecture and address model in versioned layout names

### DIFF
--- a/boostcpp.jam
+++ b/boostcpp.jam
@@ -123,7 +123,7 @@ rule tag ( name : type ? : property-set )
         if $(layout) = versioned
         {
             result = [ common.format-name
-                <base> <toolset> <threading> <runtime> -$(BOOST_VERSION_TAG)
+                <base> <toolset> <threading> <runtime> <arch-and-model> -$(BOOST_VERSION_TAG)
                 -$(BUILD_ID)
                 : $(name) : $(type) : $(property-set) ] ;
         }


### PR DESCRIPTION
This requires boostorg/build#209. The corresponding autolink change is boostorg/config#160.