### PR TITLE
Make boostbook.css work well with Sphinx

### DIFF
--- a/doc/src/boostbook.css
+++ b/doc/src/boostbook.css
@@ -5,6 +5,7 @@ http://spirit.sourceforge.net/
 
 Copyright 2013 Niall Douglas additions for colors and alignment.
 Copyright 2013 Paul A. Bristow additions for more colors and alignments.
+Copyright 2017 Tom Westerhout font fixes to support Sphinx
 
 Distributed under the Boost Software License, Version 1.0. (See accompany-
 ing file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -17,6 +18,7 @@ Body defaults
     body
     {
         margin: 1em;
+        font-size: 10pt;
         font-family: sans-serif;
     }
 
@@ -48,6 +50,7 @@ Program listings
         padding: 0.5pc 0.5pc 0.5pc 0.5pc;
     }
 
+    div.highlight,
     .programlisting,
     .screen
     {
@@ -410,16 +413,82 @@ Colors
             color: #000000;
         }
 
+        
     /* Syntax Highlighting */
+        .property,
+        .highlight .k
+        .highlight .kc
+        .highlight .kd
+        .highlight .kn
+        .highlight .kp
+        .highlight .kr
+        .highlight .kt
         .keyword { color: #0000AA; }
+
+        .highlight .n,
+        .highlight .na,
+        .highlight .nb,
+        .highlight .bp,
+        .highlight .nc,
+        .highlight .no,
+        .highlight .nd,
+        .highlight .ni,
+        .highlight .ne,
+        .highlight .nf,
+        .highlight .py,
+        .highlight .nl,
+        .highlight .nn,
+        .highlight .nx,
+        .highlight .nt,
+        .highlight .nv,
+        .highlight .vc,
+        .highlight .vg,
+        .highlight .vi,
         .identifier { color: #000000; }
+
         .special { color: #707070; }
+
+        .highlight .cp,
         .preprocessor { color: #402080; }
+
+        .highlight .sc
         .char { color: teal; }
+
+        .highlight .c
+        .highlight .ch
+        .highlight .cm
+        .highlight .cp
+        .highlight .cpf
+        .highlight .c1
+        .highlight .cs
+        .highlight .sd
+        .highlight .sh
         .comment { color: #800000; }
+
+        .highlight .s
+        .highlight .sa
+        .highlight .sb
+        .highlight .dl
+        .highlight .s2
+        .highlight .se
+        .highlight .si
+        .highlight .sx
+        .highlight .sr
+        .highlight .s1
+        .highlight .ss
         .string { color: teal; }
+
+        .highlight .m,
+        .highlight .mf,
+        .highlight .mh,
+        .highlight .mi,
+        .highlight .mo,
         .number { color: teal; }
+
+        .highlight,
         .white_bkd { background-color: #FFFFFF; }
+
+        .highlight .hll,
         .dk_grey_bkd { background-color: #999999; }
 
     /* Links */
@@ -462,6 +531,7 @@ Colors
             border: 1px solid #DCDCDC;
         }
 
+        div.highlight,
         .programlisting,
         .screen
         {
@@ -541,6 +611,7 @@ Colors
             border: 1px solid gray;
         }
 
+        div.highlight,
         .programlisting,
         .screen
         {


### PR DESCRIPTION
* `body`'s `font-size` wasn't set. It should though to avoid inconsistencies in font sizes. Fixed.
* [Sphinx](http://www.sphinx-doc.org/en/stable/index.html) uses [Pygments](http://pygments.org/) to highlight the text. Added support for it. The change shouldn't break any existing code.