### PR TITLE
Remove --valid flag from xmllint

### DIFF
--- a/status/explicit-failures-markup.xml
+++ b/status/explicit-failures-markup.xml
@@ -7,7 +7,7 @@
 
     Locally, the xmlint tool can be used:
 
-        xmllint <two-dashes>valid explicit-failures-markup.xml <two-dashes>schema explicit-failures.xsd
+        xmllint explicit-failures-markup.xml <two-dashes>schema explicit-failures.xsd
 
     The following online services can be used to validate your changes to this
     file:


### PR DESCRIPTION
The existing call to xmllint returns an error status, the error message is obscured by the output, but it writes to stderr:

    explicit-failures-markup.xml:3: validity error : Validation failed: no DTD found !
     xsi:noNamespaceSchemaLocation="explicit-failures.xsd">

According to the xmllint man page the `--valid` flag is used for validating using a DTD, and we don't have a DTD. The `--schema` flag is sufficient for validation, so I think the solution is just to remove the `--valid` flag.

I'll accept this myself if no one objects, but I wanted to give people a chance to comment.