### PR TITLE
Make all elements in explicit failures schema optional

### DIFF
--- a/status/explicit-failures.xsd
+++ b/status/explicit-failures.xsd
@@ -4,9 +4,9 @@
     <xs:element name="explicit-failures-markup">
         <xs:complexType>
             <xs:sequence>
-                <xs:element ref="mark-toolset" maxOccurs="unbounded"/>
-                <xs:element ref="library" maxOccurs="unbounded"/>
-                <xs:element ref="note" maxOccurs="unbounded"/>
+                <xs:element ref="mark-toolset" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="library" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="note" minOccurs="0" maxOccurs="unbounded"/>
             </xs:sequence>
         </xs:complexType>
     </xs:element>


### PR DESCRIPTION
This is so that this schema can be used to validate module markup (such as https://github.com/boostorg/functional/blob/develop/meta/explicit-failures-markup.xml). An alternative solution would be to have a separate schema file for submodules, espcially if the reporting scripts require these elements to be present.