### PR TITLE
Auto-detection of <threadapi> default value

### DIFF
--- a/Jamroot
+++ b/Jamroot
@@ -133,6 +133,7 @@ import notfile ;
 import virtual-target ;
 import "class" : new ;
 import property-set ;
+import threadapi-feature ;
 
 path-constant BOOST_ROOT : . ;
 constant BOOST_VERSION : 1.66.0 ;
@@ -173,6 +174,7 @@ project boost
       <toolset>como-linux:<define>_GNU_SOURCE=1
       # When building docs within Boost, we want the standard Boost style
       <xsl:param>boost.defaults=Boost
+      <conditional>@threadapi-feature.detect
     : usage-requirements <include>.
     : build-dir bin.v2
     ;


### PR DESCRIPTION
`<threadapi>` default value should be deduced from `<target-os>`. The logic is implemented in boostorg/build#251. The actual value of `<threadapi>` (taking into account build request) should be evaluated via `<conditional>` in the top-level project requirements. See also discussion [here](https://github.com/boostorg/thread/commit/e9ce83b3998a0de2a825629531c40aab55b9747c).