### PR TITLE
[status] Define test categories for Spirit

### DIFF
--- a/status/explicit-failures-markup.xml
+++ b/status/explicit-failures-markup.xml
@@ -3909,6 +3909,10 @@ for more information.
         <toolset name="borland-*"/>
         <toolset name="cray-8.0"/>
       </mark-unusable>
+      <test name="karma_*" category="Karma" />
+      <test name="qi_*" category="Qi" />
+      <test name="support_*" category="Support" />
+      <test name="x3_*" category="X3" />
     </library>
 
     <!-- spirit (v2) repository -->
@@ -3917,6 +3921,9 @@ for more information.
         <toolset name="borland-cb2009"/>
         <toolset name="borland-cb2010"/>
       </mark-unusable>
+      <test name="karma_*" category="Karma" />
+      <test name="qi_*" category="Qi" />
+      <test name="x3_*" category="X3" />
     </library>
 
     <!-- spirit (classic) -->


### PR DESCRIPTION
XML was validated with schema (It did not pass until I placed `test` entries after `mark-unusable` :astonished:).