### PR TITLE
Remove Wave special case from status/Jamfile

### DIFF
--- a/status/Jamfile.v2
+++ b/status/Jamfile.v2
@@ -196,9 +196,6 @@ run-tests libs : $(libs-to-test)/test ;
 
 # Tests from Jamfiles in individual library test subdirectories
 # Please keep these in alphabetic order by test-suite name
-run-tests libs :
-    wave/test/build             # test-suite wave
-    ;
 
 run-tests tools :
     bcp/test


### PR DESCRIPTION
No longer necessary because of https://github.com/boostorg/wave/commit/4386cce02ef30c1690c7fa4cee5aff05079a267c.