### PR TITLE
Detect ICU with pkg-config when possible.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -293,6 +293,11 @@ fi
 $ECHO -n "Unicode/ICU support for Boost.Regex?... "
 if test "x$flag_icu" != xno; then
   if test "x$ICU_ROOT" = x; then
+    if command -v pkg-config > /dev/null && pkg-config icu-uc ; then
+      ICU_ROOT=`pkg-config --variable=prefix icu-uc`
+    fi
+  fi
+  if test "x$ICU_ROOT" = x; then
     COMMON_ICU_PATHS="/usr /usr/local /sw"
     for p in $COMMON_ICU_PATHS; do
       if test -r $p/include/unicode/utypes.h; then


### PR DESCRIPTION
Better detection of ICU in bootstrap.sh with the help of pkg-config.

Checking for the header under `/usr/include/unicode` is not very robust because on some Linux distros the header is not dirctly in include. E.g. on older Ubuntu 14.04 it is in `/usr/include/x86_64-linux-gnu/unicode`.
Asking pkg-config is a better way to check if the library is installed.