### PR TITLE
Remove B2 docs ref.

### DIFF
--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -178,7 +178,6 @@ xinclude libraries :
 explicit libraries ;
 
 xinclude tools :
-    ../tools/build/doc//jam_docs
     ../tools/quickbook/doc//quickbook
     ../tools/boostbook/doc/boostbook.xml
     ../tools/build/doc//boostdoc


### PR DESCRIPTION
B2 docs are now generated outside of boostbook. This also fixes a current error on the release archive builds.