### PR TITLE
[NO MERGE] A docker build environment for boost

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,67 @@
+# Docker Containers for Boost Development #
+
+These containers have all the tools and libraries necessary
+to completely build and debug boost.  Currently this is targeting Unix builds.
+There are three scripts each provided for Windows and for Unix:
+
+* **build** will build a docker image
+* **clean** will clean up the docker cruft that accumulates
+* **run** will give you a shell prompt in a container
+
+The build and run commands take two arguments, distribution and codename.
+When building, the images will be named `boost:<dist>-<codename>`.
+The following environments are currently provided:
+
+| distribution | codename | version   | clang | gcc   | java   | openssl | python |
+| :----------- | :------- | :-------- | :---- | :---- | :----- | :------ | :----- |
+| debian       | stretch  | 9.4       | 3.8   | 6.3.0 | 8u171  | 1.1.0f  | 3.5.3  |
+| debian       | buster   | testing   | 6.0.1 | 7.3.0 | 11     | 1.1.0h  | 3.6.6  |
+| ubuntu       | xenial   | 16.04 LTS | 3.8   | 5.4.0 | 8u171  | 1.0.2g  | 3.5.2  |
+| ubuntu       | bionic   | 18.04 LTS | 6.0.0 | 7.3.0 | 10.0.1 | 1.1.0g  | 3.6.5  |
+
+## Unix ##
+
+1. Install docker-ce.
+2. Build the docker container, for example:
+
+        ~/boost$ docker/build.sh ubuntu bionic
+
+3. Run the docker container, for example:
+
+        ~/boost$ docker/run.sh ubuntu bionic
+
+4. Follow normal build instructions: bootstrap, b2 headers, and b2.
+5. Exit from the docker bash shell when done.
+
+## Windows (targeting Unix) ##
+
+1. Install Docker for Windows
+2. Share the drive your boost sources are on.
+3. Build the docker container, for example:
+
+        PS C:\Users\Me\workspace\boost> docker\build.ps1 -distro ubuntu -version bionic
+        ...
+        Successfully tagged boost:ubuntu-bionic
+
+4. Run the docker container, for example:
+
+        PS C:\Users\Me\workspace\boost> docker\run.ps1 -distro ubuntu -version bionic
+        boost@0e89ea6e8ca9:/boost$ ./bootstrap.sh --with-python=python3
+        Building Boost.Build engine with toolset gcc... tools/build/src/engine/bin.linuxx86_64/b2
+        Detecting Python version... 3.6
+        Detecting Python root... /usr
+        Unicode/ICU support for Boost.Regex?... /usr
+        Generating Boost.Build configuration in project-config.jam...
+
+        Bootstrapping is done. To build, run:
+
+            ./b2
+
+        To adjust configuration, edit 'project-config.jam'.
+
+5. Run "./b2 headers"
+6. Run "./b2 -q -j4" to build boost; see other documentation for more options.
+
+## Clean ##
+
+Run the clean script occasionally to get rid of crufty containers.

--- a/docker/build.ps1
+++ b/docker/build.ps1
@@ -1,0 +1,24 @@
+# Powershell script to build a docker build environment
+#
+# Copyright (C) 2018 James E. King III
+#
+# Use, modification, and distribution are subject to the
+# Boost Software License, Version 1.0. (See accompanying file
+# LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#
+# Usage: build.ps1 -distro <distro> -version <version> [-group <group>]
+# Example: build -distro ubuntu -version bionic
+# Result: a local docker image named boost:ubuntu-bionic
+#
+
+param
+(
+    [Parameter(Mandatory=$true)][string]$distro,
+    [Parameter(Mandatory=$true)][string]$version,
+    [string]$group = "boost"
+)
+
+$scriptdir = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition
+
+docker build --build-arg http_proxy --build-arg https_proxy --build-arg ftp_proxy -t ${group}:${distro}-${version} ${scriptdir}\${distro}\${version}

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# bash script to build a docker build environment
+#
+# Copyright (C) 2018 James E. King III
+#
+# Use, modification, and distribution are subject to the
+# Boost Software License, Version 1.0. (See accompanying file
+# LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#
+# Usage: build.sh <distro> <version> [<group>]
+# Example: build ubuntu bionic
+# Result: a local docker image named boost:ubuntu-bionic
+#
+
+distro=$1
+version=$2
+group=${3:-boost}
+scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+docker build --build-arg http_proxy --build-arg https_proxy --build-arg ftp_proxy -t ${group}:${distro}-${version} ${scriptdir}/${distro}/${version}

--- a/docker/clean.ps1
+++ b/docker/clean.ps1
@@ -1,0 +1,14 @@
+# Docker cleanup script
+# Run occasionally to remove intermediate docker cruft
+#
+# Copyright (c) 2018 James E. King III
+#
+# Use, modification, and distribution are subject to the
+# Boost Software License, Version 1.0. (See accompanying file
+# LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# Delete all stopped containers
+docker rm $(docker ps -a -q)
+
+# Delete all untagged images
+docker rmi $(docker images -q -f dangling=true)

--- a/docker/clean.sh
+++ b/docker/clean.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Docker cleanup script
+# Run occasionally to remove intermediate docker cruft
+#
+# Copyright (c) 2018 James E. King III
+#
+# Use, modification, and distribution are subject to the
+# Boost Software License, Version 1.0. (See accompanying file
+# LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# Delete all stopped containers
+docker rm $(docker ps -a -q)
+
+# Delete all untagged images
+docker rmi $(docker images -q -f dangling=true)

--- a/docker/debian/buster/Dockerfile
+++ b/docker/debian/buster/Dockerfile
@@ -1,0 +1,135 @@
+# Docker build environment for Boost on Debian Stretch
+#
+# Copyright (c) 2018 James E. King III
+#
+# Use, modification, and distribution are subject to the
+# Boost Software License, Version 1.0. (See accompanying file
+# LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+FROM debian:buster
+MAINTAINER James E. King III <jking@apache.org>
+ENV CONTAINER_USER=boost
+ENV DEBIAN_FRONTEND noninteractive
+WORKDIR /boost
+
+# Load apt-utils first, fixes warnings
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      apt-utils
+
+# Basic utilities
+
+RUN apt-get install -y --no-install-recommends \
+      bash-completion \
+      bzip2 \
+      ca-certificates \
+      curl \
+      file \
+      git \
+      patch \
+      procps \
+      sudo \
+      unzip \
+      vim \
+      wget
+
+# C++
+
+RUN apt-get install -y --no-install-recommends \
+      build-essential \
+      clang++-6 \
+      cmake \
+      gdb \
+      lcov \
+      valgrind
+
+#################################################################
+## Boost Library Dependencies
+## Do not "de-dupe" - this is a canonical list of dependencies!
+#################################################################
+
+# asio
+RUN apt-get install -y --no-install-recommends \
+      libssl-dev
+
+# beast
+RUN apt-get install -y --no-install-recommends \
+      libssl-dev \
+      zlib1g-dev
+
+# gil
+RUN apt-get install -y --no-install-recommends \
+      libjpeg-dev \
+      libpng-dev \
+      libtiff-dev \
+      zlib1g-dev
+
+# integer
+RUN apt-get install -y --no-install-recommends \
+      libgmp-dev
+
+# iostreams
+RUN apt-get install -y --no-install-recommends \
+      libbz2-dev \
+      liblzma-dev \
+      zlib1g-dev
+
+# locale
+RUN apt-get install -y --no-install-recommends \
+      libicu-dev
+
+# mpi
+RUN apt-get install -y --no-install-recommends \
+      libopenmpi-dev
+
+# python
+RUN apt-get install -y --no-install-recommends \
+      python3-dev
+
+# sync
+#     pthread-win32, but not on Unix
+
+# thread
+#     pthread-win32, but not on Unix
+
+#################################################################
+# Prerequisites for boostbook (does what setup_boostbook.sh does)
+# for documentation builds to work
+
+RUN apt-get install -y --no-install-recommends \
+      xsltproc \
+      doxygen \
+      openjdk-11-jre-headless
+
+RUN cd /opt && \
+    wget --quiet http://sourceforge.net/projects/docbook/files/docbook-xsl/1.75.2/docbook-xsl-1.75.2.tar.gz && \
+    tar xzf docbook-xsl-1.75.2.tar.gz && \
+    rm docbook-xsl-1.75.2.tar.gz
+
+RUN cd /opt && \
+    mkdir docbook-dtd-4.2 && \
+    cd docbook-dtd-4.2 && \
+    wget --quiet http://www.oasis-open.org/docbook/xml/4.2/docbook-xml-4.2.zip && \
+    unzip -q docbook-xml-4.2.zip && \
+    rm docbook-xml-4.2.zip
+
+RUN cd /opt && \
+    wget --quiet http://archive.apache.org/dist/xmlgraphics/fop/binaries/fop-0.94-bin-jdk1.4.tar.gz && \
+    tar xzf fop-0.94-bin-jdk1.4.tar.gz && \
+    rm fop-0.94-bin-jdk1.4.tar.gz
+
+#################################################################
+# Build as a regular user
+# Credit: https://github.com/delcypher/docker-ubuntu-cxx-dev/blob/master/Dockerfile
+# License: None specified at time of import
+# Add non-root user for container but give it sudo access.
+# Password is the same as the username
+RUN useradd -m ${CONTAINER_USER} && \
+    echo ${CONTAINER_USER}:${CONTAINER_USER} | chpasswd && \
+    echo "${CONTAINER_USER}  ALL=(root) ALL" >> /etc/sudoers
+RUN chsh --shell /bin/bash ${CONTAINER_USER}
+USER ${CONTAINER_USER}
+#################################################################
+
+ADD --chown=boost user-config.jam /home/boost/user-config.jam

--- a/docker/debian/buster/user-config.jam
+++ b/docker/debian/buster/user-config.jam
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2018 James E. King III
+#
+# Use, modification, and distribution are subject to the
+# Boost Software License, Version 1.0. (See accompanying file
+# LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+
+# Help bjam find clang++-6.0 for "clang"
+# (see: https://github.com/boostorg/build/issues/306)
+using clang : 6.0 : /usr/bin/clang++-6.0 ;
+using gcc : 7.3 : /usr/bin/g++-7 ;
+
+# For building documentation
+# This is what setup_boostbook.sh would do
+using boostbook
+  : /opt/docbook-xsl-1.75.2
+  : /opt/docbook-dtd-4.2
+  ;
+using xsltproc : /usr/bin/xsltproc ;
+using doxygen : /usr/bin/doxygen ;
+using fop : /opt/fop-0.94/fop : : /usr/bin/java ;
+using mpi ;

--- a/docker/debian/stretch/Dockerfile
+++ b/docker/debian/stretch/Dockerfile
@@ -1,0 +1,135 @@
+# Docker build environment for Boost on Debian Stretch
+#
+# Copyright (c) 2018 James E. King III
+#
+# Use, modification, and distribution are subject to the
+# Boost Software License, Version 1.0. (See accompanying file
+# LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+FROM debian:stretch
+MAINTAINER James E. King III <jking@apache.org>
+ENV CONTAINER_USER=boost
+ENV DEBIAN_FRONTEND noninteractive
+WORKDIR /boost
+
+# Load apt-utils first, fixes warnings
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      apt-utils
+
+# Basic utilities
+
+RUN apt-get install -y --no-install-recommends \
+      bash-completion \
+      bzip2 \
+      ca-certificates \
+      curl \
+      file \
+      git \
+      patch \
+      procps \
+      sudo \
+      unzip \
+      vim \
+      wget
+
+# C++
+
+RUN apt-get install -y --no-install-recommends \
+      build-essential \
+      clang \
+      cmake \
+      gdb \
+      lcov \
+      valgrind
+
+#################################################################
+## Boost Library Dependencies
+## Do not "de-dupe" - this is a canonical list of dependencies!
+#################################################################
+
+# asio
+RUN apt-get install -y --no-install-recommends \
+      libssl-dev
+
+# beast
+RUN apt-get install -y --no-install-recommends \
+      libssl-dev \
+      zlib1g-dev
+
+# gil
+RUN apt-get install -y --no-install-recommends \
+      libjpeg-dev \
+      libpng-dev \
+      libtiff-dev \
+      zlib1g-dev
+
+# integer
+RUN apt-get install -y --no-install-recommends \
+      libgmp-dev
+
+# iostreams
+RUN apt-get install -y --no-install-recommends \
+      libbz2-dev \
+      liblzma-dev \
+      zlib1g-dev
+
+# locale
+RUN apt-get install -y --no-install-recommends \
+      libicu-dev
+
+# mpi
+RUN apt-get install -y --no-install-recommends \
+      libopenmpi-dev
+
+# python
+RUN apt-get install -y --no-install-recommends \
+      python3-dev
+
+# sync
+#     pthread-win32, but not on Unix
+
+# thread
+#     pthread-win32, but not on Unix
+
+#################################################################
+# Prerequisites for boostbook (does what setup_boostbook.sh does)
+# for documentation builds to work
+
+RUN apt-get install -y --no-install-recommends \
+      xsltproc \
+      doxygen \
+      openjdk-8-jre-headless
+
+RUN cd /opt && \
+    wget --quiet http://sourceforge.net/projects/docbook/files/docbook-xsl/1.75.2/docbook-xsl-1.75.2.tar.gz && \
+    tar xzf docbook-xsl-1.75.2.tar.gz && \
+    rm docbook-xsl-1.75.2.tar.gz
+
+RUN cd /opt && \
+    mkdir docbook-dtd-4.2 && \
+    cd docbook-dtd-4.2 && \
+    wget --quiet http://www.oasis-open.org/docbook/xml/4.2/docbook-xml-4.2.zip && \
+    unzip -q docbook-xml-4.2.zip && \
+    rm docbook-xml-4.2.zip
+
+RUN cd /opt && \
+    wget --quiet http://archive.apache.org/dist/xmlgraphics/fop/binaries/fop-0.94-bin-jdk1.4.tar.gz && \
+    tar xzf fop-0.94-bin-jdk1.4.tar.gz && \
+    rm fop-0.94-bin-jdk1.4.tar.gz
+
+#################################################################
+# Build as a regular user
+# Credit: https://github.com/delcypher/docker-ubuntu-cxx-dev/blob/master/Dockerfile
+# License: None specified at time of import
+# Add non-root user for container but give it sudo access.
+# Password is the same as the username
+RUN useradd -m ${CONTAINER_USER} && \
+    echo ${CONTAINER_USER}:${CONTAINER_USER} | chpasswd && \
+    echo "${CONTAINER_USER}  ALL=(root) ALL" >> /etc/sudoers
+RUN chsh --shell /bin/bash ${CONTAINER_USER}
+USER ${CONTAINER_USER}
+#################################################################
+
+ADD --chown=boost user-config.jam /home/boost/user-config.jam

--- a/docker/debian/stretch/user-config.jam
+++ b/docker/debian/stretch/user-config.jam
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2018 James E. King III
+#
+# Use, modification, and distribution are subject to the
+# Boost Software License, Version 1.0. (See accompanying file
+# LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+
+# Help bjam find clang++-6.0 for "clang"
+# (see: https://github.com/boostorg/build/issues/306)
+using clang : 6.0 : /usr/bin/clang++-6.0 ;
+using gcc : 7.3 : /usr/bin/g++-7 ;
+
+# For building documentation
+# This is what setup_boostbook.sh would do
+using boostbook
+  : /opt/docbook-xsl-1.75.2
+  : /opt/docbook-dtd-4.2
+  ;
+using xsltproc : /usr/bin/xsltproc ;
+using doxygen : /usr/bin/doxygen ;
+using fop : /opt/fop-0.94/fop : : /usr/bin/java ;
+using mpi ;

--- a/docker/run.ps1
+++ b/docker/run.ps1
@@ -1,0 +1,25 @@
+# Powershell script to run a docker build environment shell
+#
+# Copyright (C) 2018 James E. King III
+#
+# Use, modification, and distribution are subject to the
+# Boost Software License, Version 1.0. (See accompanying file
+# LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#
+# Usage: run.ps1 -distro <distro> -version <version> [-group <group>]
+# Example: run -distro ubuntu -version bionic
+# Result: a bash shell in the docker image named boost:ubuntu-bionic
+#
+
+param
+(
+    [Parameter(Mandatory=$true)][string]$distro,
+    [Parameter(Mandatory=$true)][string]$version,
+    [string]$group = "boost"
+)
+
+$scriptdir = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition
+$boostroot = Split-Path -Parent -Path $scriptdir
+
+docker run -v ${boostroot}:/boost -it ${group}:${distro}-${version}

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# bash script to run a docker build environment shell
+#
+# Copyright (C) 2018 James E. King III
+#
+# Use, modification, and distribution are subject to the
+# Boost Software License, Version 1.0. (See accompanying file
+# LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#
+# Usage: run.sh <distro> <version> [<group>]
+# Example: run ubuntu bionic
+# Result: a bash shell in the docker image named boost:ubuntu-bionic
+#
+
+distro=$1
+version=$2
+group=${3:-boost}
+scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+docker run --cap-add=SYS_PTRACE --privileged --security-opt seccomp=unconfined -v ${scriptdir}/..:/boost -it ${group}:${distro}-${version}

--- a/docker/ubuntu/bionic/Dockerfile
+++ b/docker/ubuntu/bionic/Dockerfile
@@ -1,0 +1,141 @@
+# Docker build environment for Boost on Ubuntu Bionic
+#
+# Copyright (c) 2018 James E. King III
+#
+# Use, modification, and distribution are subject to the
+# Boost Software License, Version 1.0. (See accompanying file
+# LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+FROM ubuntu:bionic
+MAINTAINER James E. King III <jking@apache.org>
+ENV CONTAINER_USER=boost
+ENV DEBIAN_FRONTEND noninteractive
+WORKDIR /boost
+
+# Load apt-utils first, fixes warnings
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      apt-utils
+
+# Basic utilities
+
+RUN apt-get install -y --no-install-recommends \
+      bash-completion \
+      bzip2 \
+      ca-certificates \
+      curl \
+      file \
+      git \
+      patch \
+      procps \
+      sudo \
+      unzip \
+      vim \
+      wget
+
+# C++
+
+RUN apt-get install -y --no-install-recommends \
+      build-essential \
+      clang++-6 \
+      cmake \
+      gdb \
+      lcov \
+      valgrind
+
+#################################################################
+## Boost Library Dependencies
+## Do not "de-dupe" - this is a canonical list of dependencies!
+#################################################################
+
+# asio
+RUN apt-get install -y --no-install-recommends \
+      libssl-dev
+
+# beast
+RUN apt-get install -y --no-install-recommends \
+      libssl-dev \
+      zlib1g-dev
+
+# gil
+RUN apt-get install -y --no-install-recommends \
+      libjpeg-dev \
+      libpng-dev \
+      libtiff-dev \
+      zlib1g-dev
+
+# integer
+RUN apt-get install -y --no-install-recommends \
+      libgmp-dev
+
+# interval (for one disabled example)
+RUN apt-get install -y --no-install-recommends \
+      libgmp-dev \
+      libmpfr-dev
+
+# iostreams
+RUN apt-get install -y --no-install-recommends \
+      libbz2-dev \
+      liblzma-dev \
+      libzstd-dev \
+      zlib1g-dev
+
+# locale
+RUN apt-get install -y --no-install-recommends \
+      libicu-dev
+
+# mpi
+RUN apt-get install -y --no-install-recommends \
+      libopenmpi-dev
+
+# python
+RUN apt-get install -y --no-install-recommends \
+      python3-dev
+
+# sync
+#     pthread-win32, but not on Unix
+
+# thread
+#     pthread-win32, but not on Unix
+
+#################################################################
+# Prerequisites for boostbook (does what setup_boostbook.sh does)
+# for documentation builds to work
+
+RUN apt-get install -y --no-install-recommends \
+      xsltproc \
+      doxygen \
+      openjdk-11-jre-headless
+
+RUN cd /opt && \
+    wget --quiet http://sourceforge.net/projects/docbook/files/docbook-xsl/1.75.2/docbook-xsl-1.75.2.tar.gz && \
+    tar xzf docbook-xsl-1.75.2.tar.gz && \
+    rm docbook-xsl-1.75.2.tar.gz
+
+RUN cd /opt && \
+    mkdir docbook-dtd-4.2 && \
+    cd docbook-dtd-4.2 && \
+    wget --quiet http://www.oasis-open.org/docbook/xml/4.2/docbook-xml-4.2.zip && \
+    unzip -q docbook-xml-4.2.zip && \
+    rm docbook-xml-4.2.zip
+
+RUN cd /opt && \
+    wget --quiet http://archive.apache.org/dist/xmlgraphics/fop/binaries/fop-0.94-bin-jdk1.4.tar.gz && \
+    tar xzf fop-0.94-bin-jdk1.4.tar.gz && \
+    rm fop-0.94-bin-jdk1.4.tar.gz
+
+#################################################################
+# Build as a regular user
+# Credit: https://github.com/delcypher/docker-ubuntu-cxx-dev/blob/master/Dockerfile
+# License: None specified at time of import
+# Add non-root user for container but give it sudo access.
+# Password is the same as the username
+RUN useradd -m ${CONTAINER_USER} && \
+    echo ${CONTAINER_USER}:${CONTAINER_USER} | chpasswd && \
+    echo "${CONTAINER_USER}  ALL=(root) ALL" >> /etc/sudoers
+RUN chsh --shell /bin/bash ${CONTAINER_USER}
+USER ${CONTAINER_USER}
+#################################################################
+
+ADD --chown=boost user-config.jam /home/boost/user-config.jam

--- a/docker/ubuntu/bionic/user-config.jam
+++ b/docker/ubuntu/bionic/user-config.jam
@@ -1,0 +1,28 @@
+#
+# Copyright (C) 2018 James E. King III
+#
+# Use, modification, and distribution are subject to the
+# Boost Software License, Version 1.0. (See accompanying file
+# LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+
+# Help bjam find clang++-6.0 for "clang"
+# (see: https://github.com/boostorg/build/issues/306)
+using clang : 6.0 : /usr/bin/clang++-6.0 ;
+using gcc : 7.3 : /usr/bin/g++-7 ;
+
+# For building documentation
+# This is what setup_boostbook.sh would do
+using boostbook
+  : /opt/docbook-xsl-1.75.2
+  : /opt/docbook-dtd-4.2
+  ;
+using xsltproc : /usr/bin/xsltproc ;
+using doxygen : /usr/bin/doxygen ;
+using fop : /opt/fop-0.94/fop : : /usr/bin/java ;
+
+# Python 3.6 dev kit is installed
+using python : 3.6 ;
+
+# Enable optional MPI build
+using mpi ;

--- a/docker/ubuntu/xenial/Dockerfile
+++ b/docker/ubuntu/xenial/Dockerfile
@@ -1,0 +1,135 @@
+# Docker build environment for Boost on Ubuntu Xenial
+#
+# Copyright (c) 2018 James E. King III
+#
+# Use, modification, and distribution are subject to the
+# Boost Software License, Version 1.0. (See accompanying file
+# LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+FROM ubuntu:xenial
+MAINTAINER James E. King III <jking@apache.org>
+ENV CONTAINER_USER=boost
+ENV DEBIAN_FRONTEND noninteractive
+WORKDIR /boost
+
+# Load apt-utils first, fixes warnings
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      apt-utils
+
+# Basic utilities
+
+RUN apt-get install -y --no-install-recommends \
+      bash-completion \
+      bzip2 \
+      ca-certificates \
+      curl \
+      file \
+      git \
+      patch \
+      procps \
+      sudo \
+      unzip \
+      vim \
+      wget
+
+# C++
+
+RUN apt-get install -y --no-install-recommends \
+      build-essential \
+      clang \
+      cmake \
+      gdb \
+      lcov \
+      valgrind
+
+#################################################################
+## Boost Library Dependencies
+## Do not "de-dupe" - this is a canonical list of dependencies!
+#################################################################
+
+# asio
+RUN apt-get install -y --no-install-recommends \
+      libssl-dev
+
+# beast
+RUN apt-get install -y --no-install-recommends \
+      libssl-dev \
+      zlib1g-dev
+
+# gil
+RUN apt-get install -y --no-install-recommends \
+      libjpeg-dev \
+      libpng-dev \
+      libtiff-dev \
+      zlib1g-dev
+
+# integer
+RUN apt-get install -y --no-install-recommends \
+      libgmp-dev
+
+# iostreams
+RUN apt-get install -y --no-install-recommends \
+      libbz2-dev \
+      liblzma-dev \
+      zlib1g-dev
+
+# locale
+RUN apt-get install -y --no-install-recommends \
+      libicu-dev
+
+# mpi
+RUN apt-get install -y --no-install-recommends \
+      libopenmpi-dev
+
+# python
+RUN apt-get install -y --no-install-recommends \
+      python3-dev
+
+# sync
+#     pthread-win32, but not on Unix
+
+# thread
+#     pthread-win32, but not on Unix
+
+#################################################################
+# Prerequisites for boostbook (does what setup_boostbook.sh does)
+# for documentation builds to work
+
+RUN apt-get install -y --no-install-recommends \
+      xsltproc \
+      doxygen \
+      openjdk-8-jre-headless
+
+RUN cd /opt && \
+    wget --quiet http://sourceforge.net/projects/docbook/files/docbook-xsl/1.75.2/docbook-xsl-1.75.2.tar.gz && \
+    tar xzf docbook-xsl-1.75.2.tar.gz && \
+    rm docbook-xsl-1.75.2.tar.gz
+
+RUN cd /opt && \
+    mkdir docbook-dtd-4.2 && \
+    cd docbook-dtd-4.2 && \
+    wget --quiet http://www.oasis-open.org/docbook/xml/4.2/docbook-xml-4.2.zip && \
+    unzip -q docbook-xml-4.2.zip && \
+    rm docbook-xml-4.2.zip
+
+RUN cd /opt && \
+    wget --quiet http://archive.apache.org/dist/xmlgraphics/fop/binaries/fop-0.94-bin-jdk1.4.tar.gz && \
+    tar xzf fop-0.94-bin-jdk1.4.tar.gz && \
+    rm fop-0.94-bin-jdk1.4.tar.gz
+
+#################################################################
+# Build as a regular user
+# Credit: https://github.com/delcypher/docker-ubuntu-cxx-dev/blob/master/Dockerfile
+# License: None specified at time of import
+# Add non-root user for container but give it sudo access.
+# Password is the same as the username
+RUN useradd -m ${CONTAINER_USER} && \
+    echo ${CONTAINER_USER}:${CONTAINER_USER} | chpasswd && \
+    echo "${CONTAINER_USER}  ALL=(root) ALL" >> /etc/sudoers
+RUN chsh --shell /bin/bash ${CONTAINER_USER}
+USER ${CONTAINER_USER}
+#################################################################
+
+ADD --chown=boost user-config.jam /home/boost/user-config.jam

--- a/docker/ubuntu/xenial/user-config.jam
+++ b/docker/ubuntu/xenial/user-config.jam
@@ -1,0 +1,18 @@
+#
+# Copyright (C) 2018 James E. King III
+#
+# Use, modification, and distribution are subject to the
+# Boost Software License, Version 1.0. (See accompanying file
+# LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+
+# For building documentation
+# This is what setup_boostbook.sh would do
+using boostbook
+  : /opt/docbook-xsl-1.75.2
+  : /opt/docbook-dtd-4.2
+  ;
+using xsltproc : /usr/bin/xsltproc ;
+using doxygen : /usr/bin/doxygen ;
+using fop : /opt/fop-0.94/fop : : /usr/bin/java ;
+using mpi ;


### PR DESCRIPTION
The intention of this pull request is to make a stable docker linux build environment for boost that contains all of the library and documentation build dependencies pre-configured.  See `docker/README.md` for additional details.

### Not working (yet) ###
- `compute` doesn't have access to OpenCL in the docker instance
- `mpi` build doesn't seem to want to work despite having openmpi-dev?

### Undecided ###
- Does this belong in the superproject or in its own submodule?
- Are the helper scripts useful and common enough to keep or should we just use a readme and have people modify their own local environment with (power)shell scripts customized to their needs?

### More Details ###
- Start by downloading boost recursively to your host and installing docker.
- Build a docker container (docker/build.sh).
- Run a docker container (docker/run.sh), which maps the boost directory on your host to /boost in the container.
- Do what you would normally do to build.

When you are in a docker instance (that's a running container), everything in the /boost directory is persistent and kept on your host.  Everything else is ephemeral.  So for example if you run bootstrap.sh inside the instance, quit, start a new instance, b2 will be available since it is stored inside /boost.  Your normal development workflow should still apply; builds will be incremental in the instance since it is using a directory on your host to store all of the data.