### PR TITLE
Specify the mainline 'branch' for each submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,576 +2,719 @@
 	path = libs/system
 	url = ../system.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "multi_array"]
 	path = libs/multi_array
 	url = ../multi_array.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "math"]
 	path = libs/math
 	url = ../math.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "smart_ptr"]
 	path = libs/smart_ptr
 	url = ../smart_ptr.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "parameter"]
 	path = libs/parameter
 	url = ../parameter.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "algorithm"]
 	path = libs/algorithm
 	url = ../algorithm.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "any"]
 	path = libs/any
 	url = ../any.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "concept_check"]
 	path = libs/concept_check
 	url = ../concept_check.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "python"]
 	path = libs/python
 	url = ../python.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "tti"]
 	path = libs/tti
 	url = ../tti.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "functional"]
 	path = libs/functional
 	url = ../functional.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "config"]
 	path = libs/config
 	url = ../config.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "log"]
 	path = libs/log
 	url = ../log.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "interprocess"]
 	path = libs/interprocess
 	url = ../interprocess.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "exception"]
 	path = libs/exception
 	url = ../exception.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "foreach"]
 	path = libs/foreach
 	url = ../foreach.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "spirit"]
 	path = libs/spirit
 	url = ../spirit.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "io"]
 	path = libs/io
 	url = ../io.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "disjoint_sets"]
 	path = libs/disjoint_sets
 	url = ../disjoint_sets.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "units"]
 	path = libs/units
 	url = ../units.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "preprocessor"]
 	path = libs/preprocessor
 	url = ../preprocessor.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "format"]
 	path = libs/format
 	url = ../format.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "xpressive"]
 	path = libs/xpressive
 	url = ../xpressive.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "integer"]
 	path = libs/integer
 	url = ../integer.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "thread"]
 	path = libs/thread
 	url = ../thread.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "tokenizer"]
 	path = libs/tokenizer
 	url = ../tokenizer.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "timer"]
 	path = libs/timer
 	url = ../timer.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "inspect"]
 	path = tools/inspect
 	url = ../inspect.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "boostbook"]
 	path = tools/boostbook
 	url = ../boostbook.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "regex"]
 	path = libs/regex
 	url = ../regex.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "crc"]
 	path = libs/crc
 	url = ../crc.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "random"]
 	path = libs/random
 	url = ../random.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "serialization"]
 	path = libs/serialization
 	url = ../serialization.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "test"]
 	path = libs/test
 	url = ../test.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "date_time"]
 	path = libs/date_time
 	url = ../date_time.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "logic"]
 	path = libs/logic
 	url = ../logic.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "graph"]
 	path = libs/graph
 	url = ../graph.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "numeric_conversion"]
 	path = libs/numeric/conversion
 	url = ../numeric_conversion.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "lambda"]
 	path = libs/lambda
 	url = ../lambda.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "mpl"]
 	path = libs/mpl
 	url = ../mpl.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "typeof"]
 	path = libs/typeof
 	url = ../typeof.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "tuple"]
 	path = libs/tuple
 	url = ../tuple.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "utility"]
 	path = libs/utility
 	url = ../utility.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "dynamic_bitset"]
 	path = libs/dynamic_bitset
 	url = ../dynamic_bitset.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "assign"]
 	path = libs/assign
 	url = ../assign.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "filesystem"]
 	path = libs/filesystem
 	url = ../filesystem.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "function"]
 	path = libs/function
 	url = ../function.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "conversion"]
 	path = libs/conversion
 	url = ../conversion.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "optional"]
 	path = libs/optional
 	url = ../optional.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "property_tree"]
 	path = libs/property_tree
 	url = ../property_tree.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "bimap"]
 	path = libs/bimap
 	url = ../bimap.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "variant"]
 	path = libs/variant
 	url = ../variant.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "array"]
 	path = libs/array
 	url = ../array.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "iostreams"]
 	path = libs/iostreams
 	url = ../iostreams.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "multi_index"]
 	path = libs/multi_index
 	url = ../multi_index.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "bcp"]
 	path = tools/bcp
 	url = ../bcp.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "ptr_container"]
 	path = libs/ptr_container
 	url = ../ptr_container.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "statechart"]
 	path = libs/statechart
 	url = ../statechart.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "static_assert"]
 	path = libs/static_assert
 	url = ../static_assert.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "range"]
 	path = libs/range
 	url = ../range.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "rational"]
 	path = libs/rational
 	url = ../rational.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "iterator"]
 	path = libs/iterator
 	url = ../iterator.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "build"]
 	path = tools/build
 	url = ../build.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "quickbook"]
 	path = tools/quickbook
 	url = ../quickbook.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "graph_parallel"]
 	path = libs/graph_parallel
 	url = ../graph_parallel.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "property_map"]
 	path = libs/property_map
 	url = ../property_map.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "program_options"]
 	path = libs/program_options
 	url = ../program_options.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "detail"]
 	path = libs/detail
 	url = ../detail.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "interval"]
 	path = libs/numeric/interval
 	url = ../interval.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "ublas"]
 	path = libs/numeric/ublas
 	url = ../ublas.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "wave"]
 	path = libs/wave
 	url = ../wave.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "type_traits"]
 	path = libs/type_traits
 	url = ../type_traits.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "compatibility"]
 	path = libs/compatibility
 	url = ../compatibility.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "bind"]
 	path = libs/bind
 	url = ../bind.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "pool"]
 	path = libs/pool
 	url = ../pool.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "proto"]
 	path = libs/proto
 	url = ../proto.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "fusion"]
 	path = libs/fusion
 	url = ../fusion.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "function_types"]
 	path = libs/function_types
 	url = ../function_types.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "gil"]
 	path = libs/gil
 	url = ../gil.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "intrusive"]
 	path = libs/intrusive
 	url = ../intrusive.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "asio"]
 	path = libs/asio
 	url = ../asio.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "uuid"]
 	path = libs/uuid
 	url = ../uuid.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "litre"]
 	path = tools/litre
 	url = ../litre.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "circular_buffer"]
 	path = libs/circular_buffer
 	url = ../circular_buffer.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "mpi"]
 	path = libs/mpi
 	url = ../mpi.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "unordered"]
 	path = libs/unordered
 	url = ../unordered.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "signals2"]
 	path = libs/signals2
 	url = ../signals2.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "accumulators"]
 	path = libs/accumulators
 	url = ../accumulators.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "atomic"]
 	path = libs/atomic
 	url = ../atomic.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "scope_exit"]
 	path = libs/scope_exit
 	url = ../scope_exit.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "flyweight"]
 	path = libs/flyweight
 	url = ../flyweight.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "icl"]
 	path = libs/icl
 	url = ../icl.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "predef"]
 	path = libs/predef
 	url = ../predef.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "chrono"]
 	path = libs/chrono
 	url = ../chrono.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "polygon"]
 	path = libs/polygon
 	url = ../polygon.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "msm"]
 	path = libs/msm
 	url = ../msm.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "heap"]
 	path = libs/heap
 	url = ../heap.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "coroutine"]
 	path = libs/coroutine
 	url = ../coroutine.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "coroutine2"]
 	path = libs/coroutine2
 	url = ../coroutine2.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "ratio"]
 	path = libs/ratio
 	url = ../ratio.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "odeint"]
 	path = libs/numeric/odeint
 	url = ../odeint.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "geometry"]
 	path = libs/geometry
 	url = ../geometry.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "phoenix"]
 	path = libs/phoenix
 	url = ../phoenix.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "move"]
 	path = libs/move
 	url = ../move.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "locale"]
 	path = libs/locale
 	url = ../locale.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "auto_index"]
 	path = tools/auto_index
 	url = ../auto_index.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "container"]
 	path = libs/container
 	url = ../container.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "local_function"]
 	path = libs/local_function
 	url = ../local_function.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "context"]
 	path = libs/context
 	url = ../context.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "type_erasure"]
 	path = libs/type_erasure
 	url = ../type_erasure.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "multiprecision"]
 	path = libs/multiprecision
 	url = ../multiprecision.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "lockfree"]
 	path = libs/lockfree
 	url = ../lockfree.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "sync"]
 	path = libs/sync
 	url = ../sync.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "assert"]
 	path = libs/assert
 	url = ../assert.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "align"]
 	path = libs/align
 	url = ../align.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "type_index"]
 	path = libs/type_index
 	url = ../type_index.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "core"]
 	path = libs/core
 	url = ../core.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "throw_exception"]
 	path = libs/throw_exception
 	url = ../throw_exception.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "winapi"]
 	path = libs/winapi
 	url = ../winapi.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "boostdep"]
 	path = tools/boostdep
 	url = ../boostdep.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "lexical_cast"]
 	path = libs/lexical_cast
 	url = ../lexical_cast.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "sort"]
 	path = libs/sort
 	url = ../sort.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "convert"]
 	path = libs/convert
 	url = ../convert.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "endian"]
 	path = libs/endian
 	url = ../endian.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "vmd"]
 	path = libs/vmd
 	url = ../vmd.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "dll"]
 	path = libs/dll
 	url = ../dll.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "compute"]
 	path = libs/compute
 	url = ../compute.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "hana"]
 	path = libs/hana
 	url = ../hana.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "metaparse"]
 	path = libs/metaparse
 	url = ../metaparse.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "qvm"]
 	path = libs/qvm
 	url = ../qvm.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "fiber"]
 	path = libs/fiber
 	url = ../fiber.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "process"]
 	path = libs/process
 	url = ../process.git
-	branch = develop
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "stacktrace"]
 	path = libs/stacktrace
 	url = ../stacktrace.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "poly_collection"]
 	path = libs/poly_collection
 	url = ../poly_collection.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "beast"]
 	path = libs/beast
 	url = ../beast.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "mp11"]
 	path = libs/mp11
 	url = ../mp11.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "callable_traits"]
 	path = libs/callable_traits
 	url = ../callable_traits.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "contract"]
 	path = libs/contract
 	url = ../contract.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "check_build"]
 	path = tools/check_build
 	url = ../check_build.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "container_hash"]
 	path = libs/container_hash
 	url = ../container_hash.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "hof"]
 	path = libs/hof
 	url = ../hof.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "yap"]
 	path = libs/yap
 	url = ../yap.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "safe_numerics"]
 	path = libs/safe_numerics
 	url = ../safe_numerics.git
 	fetchRecurseSubmodules = on-demand
+	branch = .
 [submodule "parameter_python"]
 	path = libs/parameter_python
 	url = ../parameter_python.git
 	fetchRecurseSubmodules = on-demand
+	branch = .


### PR DESCRIPTION
Using the `submodule.<name>.branch` config option (in the `.gitmodules` file),
specify the mainline branch for usage by `git submodule update --remote`. The
mainline branch in most submodules is `develop`, but in a few it's still
`master`. As things are (config unspecified), git uses `master` by default but
this causes submodule updates to fail with the `--remote` option.