### PR TITLE
Avoid errors when tool submodules do not exist.

### DIFF
--- a/status/Jamfile.v2
+++ b/status/Jamfile.v2
@@ -1,5 +1,5 @@
 # Copyright 2002. Dave Abrahams
-# Copyright 2016. Rene Rivera
+# Copyright 2016-2018. Rene Rivera
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
@@ -197,7 +197,16 @@ run-tests libs : $(libs-to-test)/test ;
 # Tests from Jamfiles in tools/
 # Please keep these in alphabetical order
 
-local tools-to-test = bcp check_build quickbook ;
+local tools-to-test = ;
+for local tooldir in bcp check_build quickbook
+{
+    local jamfile = [ modules.peek project : JAMFILE ] ;
+    local jamfiles = [ path.glob [ path.join tools $(tooldir) test ] : $(jamfile) ] ;
+    if $(jamfiles)
+    {
+        tools-to-test += $(tooldir) ;
+    }
+}
 
 run-tests tools : $(tools-to-test)/test ;
 


### PR DESCRIPTION
Bring in change from develop to allow merging b2 & predef to master.