### PR TITLE
Enable hidden visibility by default

### DIFF
--- a/Jamroot
+++ b/Jamroot
@@ -177,6 +177,8 @@ project boost
       <xsl:param>boost.defaults=Boost
       <conditional>@threadapi-feature.detect
     : usage-requirements <include>.
+    : default-build
+      <visibility>hidden
     : build-dir bin.v2
     ;
 


### PR DESCRIPTION
This commit uses the new visibility feature added in https://github.com/boostorg/build/commit/898ddfa1b6888424eb292942d1014261ac7b6183 and enables hidden visibility by default for Boost libraries.

The discussion that led to this PR is here:

http://boost.2283326.n4.nabble.com/all-Request-for-out-of-the-box-visibility-support-tt4704134.html
