### PR TITLE
[CMake] Add basic CMakeLists.txt file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,45 +1,64 @@
-# version 3.8 was chosen, because it provides the cxx_std_XX compile features
-# https://cmake.org/cmake/help/v3.8/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html
-cmake_minimum_required(VERSION 3.8)
+# Copyright 2018 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+cmake_minimum_required(VERSION 3.5)
+# NOTE: Individual boost cmake files might require a higher cmake version
 
 project(boost LANGUAGES CXX)
 
-# Not all boost libraries have native support for cmake yet.
-# A quick and dirty way to work around this (at least partially) is
-# to resolve missing dependencies via a boost installation known to
-# cmake itself
-# find_package(Boost REQUIRED COMPONENTS <library list>)
+# exclude libraries and tools that don't work with the superproject yet
+# (e.g. due to missing dependencies or conflicting target definitions)
+set(boost_main_excluded_libs DUMMY_LIB_NAME CACHE string "List of libraries that will be excluded from cmake build")
+set(boost_main_excluded_tools DUMMY_LIB_NAME CACHE string "List of tools that will be excluded from cmake build")
 
-message("================= BOOST WARNING ================================================================== ")
-message("=                                                                                                = ")
-message("= Cmake support in boost is experimental and only a few libraries can be build via cmake at all. = ")
-message("=                                                                                                = ")
-message("= The supported way to build and test boost is still b2, as e.g. explained here:                 = ")
-message("= https://www.boost.org/doc/libs/1_68_0/more/getting_started/index.html                          = ")
-message("=                                                                                                = ")
-message("================================================================================================== ")
+message("
+================================ BOOST WARNING ===================================================
+=                                                                                                =
+= General cmake support in boost is EXPERIMENTAL at best and                                     =
+= only a few libraries can be build via cmake at all.                                            =
+=                                                                                                =
+= The officially supported way to build and test boost is still b2, as e.g. explained here:      =
+= https://www.boost.org/doc/libs/1_68_0/more/getting_started/index.html                          =
+=                                                                                                =
+==================================================================================================
+")
 
-#Detect and process all CMakeLists files that reside in the root folder of a library
-file(GLOB boost_lib_cmake_files libs/*/CMakeLists.txt)
+message("Manually excluded libs: ${boost_main_excluded_libs}")
+message("Manually excluded tools: ${boost_main_excluded_tools}")
 
-foreach(cmake_file IN ITEMS ${boost_lib_cmake_files})
+# Detect and process all CMakeLists files that reside in the root folder of a library
+file(GLOB boost_libs_with_cmake_files libs/*/CMakeLists.txt)
 
-	 get_filename_component(lib ${cmake_file} DIRECTORY)
+add_definitions(-DBOOST_ALL_NO_LIB)
 
-	 message("Adding boost library: ${lib}")
-	 add_subdirectory(${lib})
+foreach(cmake_file IN ITEMS ${boost_libs_with_cmake_files})
+
+    get_filename_component(dir ${cmake_file} DIRECTORY)
+    get_filename_component(lib_name ${dir} NAME)
+
+    if(lib_name IN_LIST boost_main_excluded_libs)
+        message("Ignoring boost library: ${dir}")
+    else()
+        message("Adding boost library: ${dir}")
+        add_subdirectory(${dir})
+    endif()
 
 endforeach()
 
-#Detect and process all CMakeLists files that reside in the root folder of a tool
-file(GLOB boost_tool_cmake_files tools/*/CMakeLists.txt)
+# Detect and process all CMakeLists files that reside in the root folder of a tool
+file(GLOB boost_tools_with_cmake_files tools/*/CMakeLists.txt)
 
-foreach(cmake_file IN ITEMS ${boost_tool_cmake_files})
+foreach(cmake_file IN ITEMS ${boost_tools_with_cmake_files})
 
-	 get_filename_component(lib ${cmake_file} DIRECTORY)
+    get_filename_component(dir ${cmake_file} DIRECTORY)
+    get_filename_component(tool_name ${dir} NAME)
 
-	 message("Adding boost tool: ${lib}")
-	 add_subdirectory(${lib})
-
+    if(tool_name IN_LIST boost_main_excluded_tools)
+        message("Ignoring boost tool: ${dir}")
+    else()
+        message("Adding boost tool: ${dir}")
+        add_subdirectory(${dir})
+    endif()
 endforeach()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,13 +9,11 @@ project(boost LANGUAGES CXX)
 
 #=== options ===
 
-option(boost_include_tools "Set to ON if (cmake compatible) boost tools should also be build (default is OFF)")
-# exclude libraries and tools that don't work with the superproject yet
+# exclude libraries that don't work with the superproject yet
 # (e.g. due to missing dependencies or conflicting target definitions)
+
 set(boost_main_excluded_libs dummy1;dummy2;dummy3 CACHE string "List of libraries that will be excluded from cmake build")
-if(boost_include_tools)
-    set(boost_main_excluded_tools dummy1;dummy2;dummy3 CACHE string "List of tools that will be excluded from cmake build")
-endif()
+
 
 #~~~ options ~~~
 
@@ -55,24 +53,3 @@ foreach(cmake_file IN ITEMS ${boost_libs_with_cmake_files})
     endif()
 
 endforeach()
-
-if(boost_include_tools)
-    message("Manually excluded tools: ${boost_main_excluded_tools}")
-
-    # Detect and process all CMakeLists files that reside in the root folder of a tool
-    file(GLOB boost_tools_with_cmake_files tools/*/CMakeLists.txt)
-
-    foreach(cmake_file IN ITEMS ${boost_tools_with_cmake_files})
-        get_filename_component(dir ${cmake_file} DIRECTORY)
-        get_filename_component(tool_name ${dir} NAME)
-
-        if(tool_name IN_LIST boost_main_excluded_tools)
-            message("Ignoring boost tool: ${dir}")
-        else()
-            message("Adding boost tool: ${dir}")
-            add_subdirectory(${dir})
-        endif()
-    endforeach()
-
-endif() #boost_include_tools
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,18 @@ cmake_minimum_required(VERSION 3.5)
 
 project(boost LANGUAGES CXX)
 
+#=== options ===
+
+option(boost_include_tools "Set to ON if (cmake compatible) boost tools should also be build (default is OFF)")
 # exclude libraries and tools that don't work with the superproject yet
 # (e.g. due to missing dependencies or conflicting target definitions)
-set(boost_main_excluded_libs DUMMY_LIB_NAME CACHE string "List of libraries that will be excluded from cmake build")
-set(boost_main_excluded_tools DUMMY_LIB_NAME CACHE string "List of tools that will be excluded from cmake build")
+set(boost_main_excluded_libs dummy1;dummy2;dummy3 CACHE string "List of libraries that will be excluded from cmake build")
+if(boost_include_tools)
+    set(boost_main_excluded_tools dummy1;dummy2;dummy3 CACHE string "List of tools that will be excluded from cmake build")
+endif()
+
+#~~~ options ~~~
+
 
 message("
 ================================ BOOST WARNING ===================================================
@@ -25,12 +33,14 @@ message("
 ")
 
 message("Manually excluded libs: ${boost_main_excluded_libs}")
-message("Manually excluded tools: ${boost_main_excluded_tools}")
+
+# cmake doesn't require autolinking and currently most cmake files don't produce
+# name mangled libraries anyway
+message("Deactivating boost auto linking mechanism (-DBOOST_ALL_NO_LIB)")
+add_definitions(-DBOOST_ALL_NO_LIB)
 
 # Detect and process all CMakeLists files that reside in the root folder of a library
 file(GLOB boost_libs_with_cmake_files libs/*/CMakeLists.txt)
-
-add_definitions(-DBOOST_ALL_NO_LIB)
 
 foreach(cmake_file IN ITEMS ${boost_libs_with_cmake_files})
 
@@ -46,19 +56,23 @@ foreach(cmake_file IN ITEMS ${boost_libs_with_cmake_files})
 
 endforeach()
 
-# Detect and process all CMakeLists files that reside in the root folder of a tool
-file(GLOB boost_tools_with_cmake_files tools/*/CMakeLists.txt)
+if(boost_include_tools)
+    message("Manually excluded tools: ${boost_main_excluded_tools}")
 
-foreach(cmake_file IN ITEMS ${boost_tools_with_cmake_files})
+    # Detect and process all CMakeLists files that reside in the root folder of a tool
+    file(GLOB boost_tools_with_cmake_files tools/*/CMakeLists.txt)
 
-    get_filename_component(dir ${cmake_file} DIRECTORY)
-    get_filename_component(tool_name ${dir} NAME)
+    foreach(cmake_file IN ITEMS ${boost_tools_with_cmake_files})
+        get_filename_component(dir ${cmake_file} DIRECTORY)
+        get_filename_component(tool_name ${dir} NAME)
 
-    if(tool_name IN_LIST boost_main_excluded_tools)
-        message("Ignoring boost tool: ${dir}")
-    else()
-        message("Adding boost tool: ${dir}")
-        add_subdirectory(${dir})
-    endif()
-endforeach()
+        if(tool_name IN_LIST boost_main_excluded_tools)
+            message("Ignoring boost tool: ${dir}")
+        else()
+            message("Adding boost tool: ${dir}")
+            add_subdirectory(${dir})
+        endif()
+    endforeach()
+
+endif() #boost_include_tools
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,45 @@
+# version 3.8 was chosen, because it provides the cxx_std_XX compile features
+# https://cmake.org/cmake/help/v3.8/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html
+cmake_minimum_required(VERSION 3.8)
+
+project(boost LANGUAGES CXX)
+
+# Not all boost libraries have native support for cmake yet.
+# A quick and dirty way to work around this (at least partially) is
+# to resolve missing dependencies via a boost installation known to
+# cmake itself
+# find_package(Boost REQUIRED COMPONENTS <library list>)
+
+message("================= BOOST WARNING ================================================================== ")
+message("=                                                                                                = ")
+message("= Cmake support in boost is experimental and only a few libraries can be build via cmake at all. = ")
+message("=                                                                                                = ")
+message("= The supported way to build and test boost is still b2, as e.g. explained here:                 = ")
+message("= https://www.boost.org/doc/libs/1_68_0/more/getting_started/index.html                          = ")
+message("=                                                                                                = ")
+message("================================================================================================== ")
+
+#Detect and process all CMakeLists files that reside in the root folder of a library
+file(GLOB boost_lib_cmake_files libs/*/CMakeLists.txt)
+
+foreach(cmake_file IN ITEMS ${boost_lib_cmake_files})
+
+	 get_filename_component(lib ${cmake_file} DIRECTORY)
+
+	 message("Adding boost library: ${lib}")
+	 add_subdirectory(${lib})
+
+endforeach()
+
+#Detect and process all CMakeLists files that reside in the root folder of a tool
+file(GLOB boost_tool_cmake_files tools/*/CMakeLists.txt)
+
+foreach(cmake_file IN ITEMS ${boost_tool_cmake_files})
+
+	 get_filename_component(lib ${cmake_file} DIRECTORY)
+
+	 message("Adding boost tool: ${lib}")
+	 add_subdirectory(${lib})
+
+endforeach()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2018 Mike Dev
 # Distributed under the Boost Software License, Version 1.0.
-# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+# See accompanying file LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt
 
 cmake_minimum_required(VERSION 3.5)
 # NOTE: Individual boost cmake files might require a higher cmake version
@@ -9,14 +9,16 @@ project(boost LANGUAGES CXX)
 
 #=== options ===
 
-# exclude libraries that don't work with the superproject yet
-# (e.g. due to missing dependencies or conflicting target definitions)
-
-set(boost_main_excluded_libs dummy1;dummy2;dummy3 CACHE string "List of libraries that will be excluded from cmake build")
+# Some libraries' cmake files don't work well with this cmake file, e.g. because
+# - they are generally not designed to support the add_subdirectory workflow at all
+# - they define targets with conflicting names (e.g. check)
+# - require some additional (internal or external) dependencies
+#
+# Those libraries can be excluded here
+set(BOOST_MAIN_IGNORE_LIBS callable_traits;compute;gil;hana;yap;safe_numerics;beast CACHE string "List of libraries that will be excluded from cmake build")
 
 
 #~~~ options ~~~
-
 
 message("
 ================================ BOOST WARNING ===================================================
@@ -25,12 +27,12 @@ message("
 = only a few libraries can be build via cmake at all.                                            =
 =                                                                                                =
 = The officially supported way to build and test boost is still b2, as e.g. explained here:      =
-= https://www.boost.org/doc/libs/1_68_0/more/getting_started/index.html                          =
+= https://www.boost.org/doc/libs/1_69_0/more/getting_started/index.html                          =
 =                                                                                                =
 ==================================================================================================
 ")
 
-message("Manually excluded libs: ${boost_main_excluded_libs}")
+message("Excluded libs (BOOST_MAIN_IGNORE_LIBS): ${BOOST_MAIN_IGNORE_LIBS}")
 
 # cmake doesn't require autolinking and currently most cmake files don't produce
 # name mangled libraries anyway
@@ -40,12 +42,12 @@ add_definitions(-DBOOST_ALL_NO_LIB)
 # Detect and process all CMakeLists files that reside in the root folder of a library
 file(GLOB boost_libs_with_cmake_files libs/*/CMakeLists.txt)
 
-foreach(cmake_file IN ITEMS ${boost_libs_with_cmake_files})
+foreach(cmake_file IN LISTS boost_libs_with_cmake_files)
 
     get_filename_component(dir ${cmake_file} DIRECTORY)
     get_filename_component(lib_name ${dir} NAME)
 
-    if(lib_name IN_LIST boost_main_excluded_libs)
+    if(lib_name IN_LIST BOOST_MAIN_IGNORE_LIBS)
         message("Ignoring boost library: ${dir}")
     else()
         message("Adding boost library: ${dir}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,11 +32,11 @@ message("
 ==================================================================================================
 ")
 
-message("[Boost] Excluded libs (BOOST_MAIN_IGNORE_LIBS): ${BOOST_MAIN_IGNORE_LIBS}")
+message(STATUS "[Boost] Excluded libs (BOOST_MAIN_IGNORE_LIBS): ${BOOST_MAIN_IGNORE_LIBS}")
 
 # cmake doesn't require autolinking and currently most cmake files don't produce
 # name mangled libraries anyway
-message("[Boost] Deactivating boost auto linking mechanism (-DBOOST_ALL_NO_LIB)")
+message(STATUS "[Boost] Deactivating boost auto linking mechanism (-DBOOST_ALL_NO_LIB)")
 add_definitions(-DBOOST_ALL_NO_LIB)
 
 # Detect and process all CMakeLists files that reside in the root folder of a library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,11 +32,11 @@ message("
 ==================================================================================================
 ")
 
-message("Excluded libs (BOOST_MAIN_IGNORE_LIBS): ${BOOST_MAIN_IGNORE_LIBS}")
+message("[Boost] Excluded libs (BOOST_MAIN_IGNORE_LIBS): ${BOOST_MAIN_IGNORE_LIBS}")
 
 # cmake doesn't require autolinking and currently most cmake files don't produce
 # name mangled libraries anyway
-message("Deactivating boost auto linking mechanism (-DBOOST_ALL_NO_LIB)")
+message("[Boost] Deactivating boost auto linking mechanism (-DBOOST_ALL_NO_LIB)")
 add_definitions(-DBOOST_ALL_NO_LIB)
 
 # Detect and process all CMakeLists files that reside in the root folder of a library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,10 +47,7 @@ foreach(cmake_file IN LISTS boost_libs_with_cmake_files)
     get_filename_component(dir ${cmake_file} DIRECTORY)
     get_filename_component(lib_name ${dir} NAME)
 
-    if(lib_name IN_LIST BOOST_MAIN_IGNORE_LIBS)
-        message("Ignoring boost library: ${dir}")
-    else()
-        message("Adding boost library: ${dir}")
+    if(NOT lib_name IN_LIST BOOST_MAIN_IGNORE_LIBS)
         add_subdirectory(${dir})
     endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ message(STATUS "[Boost] Excluded libs (BOOST_MAIN_IGNORE_LIBS): ${BOOST_MAIN_IGN
 # name mangled libraries anyway
 message(STATUS "[Boost] Deactivating boost auto linking mechanism (-DBOOST_ALL_NO_LIB)")
 add_definitions(-DBOOST_ALL_NO_LIB)
+enable_testing()
 
 # Detect and process all CMakeLists files that reside in the root folder of a library
 file(GLOB boost_libs_with_cmake_files libs/*/CMakeLists.txt)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ project(boost LANGUAGES CXX)
 # - require some additional (internal or external) dependencies
 #
 # Those libraries can be excluded here
-set(BOOST_MAIN_IGNORE_LIBS callable_traits;compute;gil;hana;yap;safe_numerics;beast CACHE string "List of libraries that will be excluded from cmake build")
+set(BOOST_MAIN_IGNORE_LIBS callable_traits;hof;compute;gil;hana;yap;safe_numerics;beast CACHE string "List of libraries that will be excluded from cmake build")
 
 
 #~~~ options ~~~

--- a/libs/numeric/CMakeLists.txt
+++ b/libs/numeric/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Copyright 2018 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+file(GLOB boost_numeric_libs_with_cmake_files */CMakeLists.txt)
+
+foreach(cmake_file IN ITEMS ${boost_numeric_libs_with_cmake_files})
+
+    get_filename_component(dir ${cmake_file} DIRECTORY)
+    get_filename_component(lib_name ${dir} NAME)
+
+    if(lib_name IN_LIST boost_main_excluded_libs OR "numeric/${lib_name}" IN_LIST boost_main_excluded_libs)
+        message("Ignoring boost library: ${dir}")
+    else()
+        message("Adding boost library: ${dir}")
+        add_subdirectory(${dir})
+    endif()
+
+endforeach()
+

--- a/libs/numeric/CMakeLists.txt
+++ b/libs/numeric/CMakeLists.txt
@@ -4,12 +4,12 @@
 
 file(GLOB boost_numeric_libs_with_cmake_files */CMakeLists.txt)
 
-foreach(cmake_file IN ITEMS ${boost_numeric_libs_with_cmake_files})
+foreach(cmake_file IN LISTS boost_numeric_libs_with_cmake_files)
 
     get_filename_component(dir ${cmake_file} DIRECTORY)
     get_filename_component(lib_name ${dir} NAME)
 
-    if(lib_name IN_LIST boost_main_excluded_libs OR "numeric/${lib_name}" IN_LIST boost_main_excluded_libs)
+    if(lib_name IN_LIST BOOST_MAIN_IGNORE_LIBS OR "numeric/${lib_name}" IN_LIST BOOST_MAIN_IGNORE_LIBS)
         message("Ignoring boost library: ${dir}")
     else()
         message("Adding boost library: ${dir}")

--- a/libs/numeric/CMakeLists.txt
+++ b/libs/numeric/CMakeLists.txt
@@ -9,10 +9,7 @@ foreach(cmake_file IN LISTS boost_numeric_libs_with_cmake_files)
     get_filename_component(dir ${cmake_file} DIRECTORY)
     get_filename_component(lib_name ${dir} NAME)
 
-    if(lib_name IN_LIST BOOST_MAIN_IGNORE_LIBS OR "numeric/${lib_name}" IN_LIST BOOST_MAIN_IGNORE_LIBS)
-        message("Ignoring boost library: ${dir}")
-    else()
-        message("Adding boost library: ${dir}")
+    if(NOT (lib_name IN_LIST BOOST_MAIN_IGNORE_LIBS OR "numeric/${lib_name}" IN_LIST BOOST_MAIN_IGNORE_LIBS))
         add_subdirectory(${dir})
     endif()
 


### PR DESCRIPTION
The file just processes all CMakeLists.txt files
that it findes in one of the library or tool root
directories.

Further reference: https://groups.google.com/forum/#!topic/boost-developers-archive/kM4JRmyVl3M