### PR TITLE
Set default local-visibility instead of visibility

### DIFF
--- a/Jamroot
+++ b/Jamroot
@@ -178,7 +178,7 @@ project boost
       <conditional>@threadapi-feature.detect
     : usage-requirements <include>.
     : default-build
-      <visibility>hidden
+      <local-visibility>hidden
     : build-dir bin.v2
     ;
 


### PR DESCRIPTION
This is a result of the discussion in https://github.com/boostorg/build/pull/333.

This PR depends on merging https://github.com/boostorg/build/pull/345 first.