### PR TITLE
do not add version suffix for android

### DIFF
--- a/boostcpp.jam
+++ b/boostcpp.jam
@@ -198,7 +198,7 @@ rule tag ( name : type ? : property-set )
         # libFoo.1.2.3.dylib format. AIX linkers do not accept version suffixes
         # either. Pgi compilers can not accept a library with version suffix.
         if $(type) = SHARED_LIB &&
-          ! [ $(property-set).get <target-os> ] in windows cygwin darwin aix &&
+          ! [ $(property-set).get <target-os> ] in windows cygwin darwin aix android &&
           ! [ $(property-set).get <toolset> ] in pgi
         {
             result = $(result).$(BOOST_VERSION)  ;


### PR DESCRIPTION
Android studio could automatically pack shared libraries into final apk. But if we link to `libboost_system.so`, which is a soft link to `libboost_system.so.1.68.0`, only the former will be packed.