### PR TITLE
Add SaxonHE to dependencies list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ addons:
       - texlive
       - sshpass
       - ghostscript
+      - libsaxonhe-java
   ssh_known_hosts: frs.sourceforge.net
 
 env:


### PR DESCRIPTION
Used by Boost.Beast in doc reference generation.