### PR TITLE
Removed Boost.Signals from Getting Started documentation

### DIFF
--- a/more/getting_started/detail/header-only.rst
+++ b/more/getting_started/detail/header-only.rst
@@ -32,7 +32,6 @@ The only Boost libraries that *must* be built separately are:
   before building and installing it)
 * Boost.Regex_
 * Boost.Serialization_
-* Boost.Signals_
 * Boost.System_
 * Boost.Thread_
 * Boost.Timer_

--- a/more/getting_started/detail/links.rst
+++ b/more/getting_started/detail/links.rst
@@ -19,7 +19,6 @@
 .. _Boost.Random: ../../libs/random/index.html
 .. _Boost.Regex: ../../libs/regex/index.html
 .. _Boost.Serialization: ../../libs/serialization/index.html
-.. _Boost.Signals: ../../libs/signals/index.html
 .. _Boost.System: ../../libs/system/index.html
 .. _Boost.Test: ../../libs/test/index.html
 .. _Boost.Thread: ../../libs/thread/index.html

--- a/more/getting_started/unix-variants.html
+++ b/more/getting_started/unix-variants.html
@@ -192,7 +192,6 @@ treatment when linking.</p>
 before building and installing it)</li>
 <li><a class="reference external" href="../../libs/regex/index.html">Boost.Regex</a></li>
 <li><a class="reference external" href="../../libs/serialization/index.html">Boost.Serialization</a></li>
-<li><a class="reference external" href="../../libs/signals/index.html">Boost.Signals</a></li>
 <li><a class="reference external" href="../../libs/system/index.html">Boost.System</a></li>
 <li><a class="reference external" href="../../libs/thread/index.html">Boost.Thread</a></li>
 <li><a class="reference external" href="../../libs/timer/index.html">Boost.Timer</a></li>

--- a/more/getting_started/windows.html
+++ b/more/getting_started/windows.html
@@ -177,7 +177,6 @@ treatment when linking.</p>
 before building and installing it)</li>
 <li><a class="reference external" href="../../libs/regex/index.html">Boost.Regex</a></li>
 <li><a class="reference external" href="../../libs/serialization/index.html">Boost.Serialization</a></li>
-<li><a class="reference external" href="../../libs/signals/index.html">Boost.Signals</a></li>
 <li><a class="reference external" href="../../libs/system/index.html">Boost.System</a></li>
 <li><a class="reference external" href="../../libs/thread/index.html">Boost.Thread</a></li>
 <li><a class="reference external" href="../../libs/timer/index.html">Boost.Timer</a></li>


### PR DESCRIPTION
Updated the Getting Started documentation to reflect that Boost.Signals is no longer part of Boost.