### PR TITLE
unmarked some optional tests

### DIFF
--- a/status/explicit-failures-markup.xml
+++ b/status/explicit-failures-markup.xml
@@ -3420,32 +3420,6 @@ for more information.
          <!-- optional -->
     <library name="optional">
         <mark-expected-failures>
-            <test name="optional_test_ref_assign_const_int"/>
-            <toolset name="msvc-10.0"/>
-            <note author="Andrzej Krzemienski" id="optional-const-int-ref-bug">
-                <p>This is a compiler bug: it sometimes creates an illegal temporary object.
-		The following code illustrates the bug:</p>
-		<pre>
-		#include &lt;cassert&gt;
-		const int global_i = 0;
-		
-		struct TestingReferenceBinding
-		{
-		  void operator=(const int&amp; ii)
-		  {
-		    assert(&amp;ii == &amp;global_i);
-		  }
-		};
-		
-		int main()
-		{
-		  TestingReferenceBinding ttt;
-		  ttt = global_i;
-		}
-                </pre>
-            </note>
-        </mark-expected-failures>
-        <mark-expected-failures>
             <test name="optional_test_ref_converting_ctor"/>
             <toolset name="gcc-4.4*"/>
             <toolset name="gcc-4.2.1"/>
@@ -3477,17 +3451,6 @@ for more information.
                 </pre>
             </note>
         </mark-expected-failures>
-        <mark-expected-failures>
-		<test name="optional_test_ref_convert_assign_const_int"/>
-		<toolset name="msvc-8.0"/>
-		<toolset name="msvc-9.0"/>
-		<toolset name="msvc-10.0"/>
-		<toolset name="msvc-11.0"/>
-		<toolset name="msvc-12.0"/>
-		<note author="Andrzej Krzemienski" id="optional-const-int-ref-assign-bug">
-			<p>This is a compiler bug: it sometimes creates an illegal temporary object.</p>
-		</note>
-	</mark-expected-failures>
         <mark-expected-failures>
             <test name="optional_test_ref"/>
             <toolset name="msvc-6.5*"/>


### PR DESCRIPTION
Ever since optional references have been rewritten these tests pass in MSVC.