### PR TITLE
Add support for S390x

### DIFF
--- a/boostcpp.jam
+++ b/boostcpp.jam
@@ -607,7 +607,7 @@ rule address-model ( )
     return <conditional>@boostcpp.deduce-address-model ;
 }
 
-local deducable-architectures = arm mips1 power sparc s390 x86 combined ;
+local deducable-architectures = arm mips1 power sparc s390x x86 combined ;
 feature.feature deduced-architecture : $(deducable-architectures) : propagated optional composite hidden ;
 for a in $(deducable-architectures)
 {
@@ -618,13 +618,13 @@ rule deduce-architecture ( properties * )
 {
     local result ;
     local filtered = [ toolset-properties $(properties) ] ;
-    local names = arm mips1 power sparc s390 x86 combined ;
+    local names = arm mips1 power sparc s390x x86 combined ;
     local idx = [ configure.find-builds "default architecture" : $(filtered)
         : /boost/architecture//arm
         : /boost/architecture//mips1
         : /boost/architecture//power
         : /boost/architecture//sparc
-        : /boost/architecture//s390
+        : /boost/architecture//s390x
         : /boost/architecture//x86
         : /boost/architecture//combined ] ;
     result = $(names[$(idx)]) ;

--- a/boostcpp.jam
+++ b/boostcpp.jam
@@ -607,7 +607,7 @@ rule address-model ( )
     return <conditional>@boostcpp.deduce-address-model ;
 }
 
-local deducable-architectures = arm mips1 power sparc x86 combined ;
+local deducable-architectures = arm mips1 power sparc s390 x86 combined ;
 feature.feature deduced-architecture : $(deducable-architectures) : propagated optional composite hidden ;
 for a in $(deducable-architectures)
 {
@@ -618,12 +618,13 @@ rule deduce-architecture ( properties * )
 {
     local result ;
     local filtered = [ toolset-properties $(properties) ] ;
-    local names = arm mips1 power sparc x86 combined ;
+    local names = arm mips1 power sparc s390 x86 combined ;
     local idx = [ configure.find-builds "default architecture" : $(filtered)
         : /boost/architecture//arm
         : /boost/architecture//mips1
         : /boost/architecture//power
         : /boost/architecture//sparc
+        : /boost/architecture//s390
         : /boost/architecture//x86
         : /boost/architecture//combined ] ;
     result = $(names[$(idx)]) ;


### PR DESCRIPTION
Add s390x as a supported architecture:

* boostcpp.jam
    - Add s390x to deduced architecture lists