### PR TITLE
Add S390x as a supported architecture

### DIFF
--- a/boostcpp.jam
+++ b/boostcpp.jam
@@ -607,7 +607,7 @@ rule address-model ( )
     return <conditional>@boostcpp.deduce-address-model ;
 }
 
-local deducable-architectures = arm mips1 power sparc x86 combined ;
+local deducable-architectures = arm mips1 power s390x sparc x86 combined ;
 feature.feature deduced-architecture : $(deducable-architectures) : propagated optional composite hidden ;
 for a in $(deducable-architectures)
 {
@@ -618,7 +618,7 @@ rule deduce-architecture ( properties * )
 {
     local result ;
     local filtered = [ toolset-properties $(properties) ] ;
-    local names = arm mips1 power sparc x86 combined ;
+    local names = arm mips1 power s390x sparc x86 combined ;
     local idx = [ configure.find-builds "default architecture" : $(filtered)
         : /boost/architecture//arm
         : /boost/architecture//mips1


### PR DESCRIPTION
Add s390x as a supported architecture:

* boostcpp.jam
    - Add s390x to list of deduced architectures