### PR TITLE
Allow spaces in $PYTHON_ROOT

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -360,7 +360,7 @@ if test "x$flag_no_python" = x; then
 import python ;
 if ! [ python.configured ]
 {
-    using python : $PYTHON_VERSION : $PYTHON_ROOT ;
+    using python : $PYTHON_VERSION : "$PYTHON_ROOT" ;
 }
 EOF
 fi


### PR DESCRIPTION
This may be the case with, for example, `C:\Program Files\Python37` on MSYS2 on Windows (with `MSYS2_PATH_TYPE=inherit` in the .ini file).