### PR TITLE
Fix bootstrap scripts

### DIFF
--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -8,10 +8,6 @@ REM Distributed under the Boost Software License, Version 1.0.
 REM (See accompanying file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
 
 ECHO Building Boost.Build engine
-if exist ".\tools\build\src\engine\bin.ntx86\b2.exe" del tools\build\src\engine\bin.ntx86\b2.exe
-if exist ".\tools\build\src\engine\bin.ntx86\bjam.exe" del tools\build\src\engine\bin.ntx86\bjam.exe
-if exist ".\tools\build\src\engine\bin.ntx86_64\b2.exe" del tools\build\src\engine\bin.ntx86_64\b2.exe
-if exist ".\tools\build\src\engine\bin.ntx86_64\bjam.exe" del tools\build\src\engine\bin.ntx86_64\bjam.exe
 pushd tools\build\src\engine
 
 call .\build.bat %* > ..\..\..\..\bootstrap.log
@@ -19,14 +15,9 @@ call .\build.bat %* > ..\..\..\..\bootstrap.log
 
 popd
 
-if exist ".\tools\build\src\engine\bin.ntx86\bjam.exe" (
-   copy .\tools\build\src\engine\bin.ntx86\b2.exe . > nul
-   copy .\tools\build\src\engine\bin.ntx86\bjam.exe . > nul
-   goto :bjam_built)
-
-if exist ".\tools\build\src\engine\bin.ntx86_64\bjam.exe" (
-   copy .\tools\build\src\engine\bin.ntx86_64\b2.exe . > nul
-   copy .\tools\build\src\engine\bin.ntx86_64\bjam.exe . > nul
+if exist ".\tools\build\src\engine\bjam.exe" (
+   copy .\tools\build\src\engine\b2.exe . > nul
+   copy .\tools\build\src\engine\bjam.exe . > nul
    goto :bjam_built)
 
 goto :bjam_failure

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -230,11 +230,10 @@ if test "x$BJAM" = x; then
       exit 1
   fi
   cd "$pwd"
-  arch=`cd $my_dir/tools/build/src/engine && ./bootstrap/jam0 -d0 -f build.jam --toolset=$TOOLSET --toolset-root= --show-locate-target && cd ..`
-  BJAM="$my_dir/tools/build/src/engine/$arch/b2"
-  echo "tools/build/src/engine/$arch/b2"
+  BJAM="$my_dir/tools/build/src/engine/b2"
+  echo "tools/build/src/engine/b2"
   cp "$BJAM" .
-  cp "$my_dir/tools/build/src/engine/$arch/bjam" .
+  cp "$my_dir/tools/build/src/engine/bjam" .
 
 fi
 


### PR DESCRIPTION
Commit boostorg/build@cc51c68c9ed6 in the submodule was in response to a change in the output location of the `bjam`/`b2` build. Apply the same change to the top-level bootstrap scripts so that they can find them.