### PR TITLE
"Merge" from develop.

### DIFF
--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -2,16 +2,14 @@
 
 SETLOCAL
 
+REM Copyright 2019 Rene Rivera
 REM Copyright (C) 2009 Vladimir Prus
 REM
 REM Distributed under the Boost Software License, Version 1.0.
 REM (See accompanying file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
 
 ECHO Building Boost.Build engine
-if exist ".\tools\build\src\engine\bin.ntx86\b2.exe" del tools\build\src\engine\bin.ntx86\b2.exe
-if exist ".\tools\build\src\engine\bin.ntx86\bjam.exe" del tools\build\src\engine\bin.ntx86\bjam.exe
-if exist ".\tools\build\src\engine\bin.ntx86_64\b2.exe" del tools\build\src\engine\bin.ntx86_64\b2.exe
-if exist ".\tools\build\src\engine\bin.ntx86_64\bjam.exe" del tools\build\src\engine\bin.ntx86_64\bjam.exe
+if exist ".\tools\build\src\engine\b2.exe" del tools\build\src\engine\b2.exe
 pushd tools\build\src\engine
 
 call .\build.bat %* > ..\..\..\..\bootstrap.log
@@ -19,14 +17,8 @@ call .\build.bat %* > ..\..\..\..\bootstrap.log
 
 popd
 
-if exist ".\tools\build\src\engine\bin.ntx86\bjam.exe" (
-   copy .\tools\build\src\engine\bin.ntx86\b2.exe . > nul
-   copy .\tools\build\src\engine\bin.ntx86\bjam.exe . > nul
-   goto :bjam_built)
-
-if exist ".\tools\build\src\engine\bin.ntx86_64\bjam.exe" (
-   copy .\tools\build\src\engine\bin.ntx86_64\b2.exe . > nul
-   copy .\tools\build\src\engine\bin.ntx86_64\bjam.exe . > nul
+if exist ".\tools\build\src\engine\b2.exe" (
+   copy .\tools\build\src\engine\b2.exe . > nul
    goto :bjam_built)
 
 goto :bjam_failure


### PR DESCRIPTION
The location of b2 execs changed with release. Need this, or merge of previous equivalent PR, to fix `bootstrap.bat` errors.