### PR TITLE
Properly detect python header files

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -283,7 +283,7 @@ if test "x$flag_no_python" = x; then
 
     if test "x$PYTHON_ROOT" = x; then
         $ECHO -n "Detecting Python root... "
-        PYTHON_ROOT=`$PYTHON -c "import sys; print(sys.prefix)"`
+        PYTHON_ROOT=`$PYTHON -c "from sysconfig import get_paths as gp; print(gp()['include'])"`
         echo $PYTHON_ROOT
     fi    
 fi


### PR DESCRIPTION
The original code use `python -c "import sys; print(sys.prefix)"` which did not show actual directory for include file.

The proper way is `python -c "from sysconfig import get_paths as gp; print(gp()['include'])"`