### PR TITLE
Add how-to clone the superproject to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,38 @@ and does not require attribution for binary use.
 
 The project website is www.boost.org, where you can obtain more information and
 [download](https://www.boost.org/users/download/) the current release.
+
+## Cloning
+
+Clone the superproject repository with all submodules and checkout the `master` as the default branch:
+
+```console
+git clone --recurse-submodules https://github.com/boostorg/boost.git boost-root
+```
+
+or checkout the `develop` branch with the latest development snapshot:
+
+```console
+git clone --branch develop --recurse-submodules https://github.com/boostorg/boost.git boost-root
+```
+
+Alternatively, clone just the superproject repository, then clone a desired submodule together with its dependencies:
+
+```console
+git clone https://github.com/boostorg/boost.git boost-root
+cd boost-root
+git submodule update --init tools/boostdep
+python tools/boostdep/depinst/depinst.py filesystem
+```
+
+Alternatively, clone just the superproject repository, then manually pick individual submodules:
+
+```console
+git clone https://github.com/boostorg/boost.git boost-root
+cd boost-root
+git submodule --quiet update --init \
+    tools/build \
+    tools/boost_install \
+    tools/boostdep \
+    libs/headers
+```


### PR DESCRIPTION
Simplest way to address these issues https://lists.boost.org/Archives/boost/2020/04/248731.php

If one aims to clone a repo from GitHub, then README.md is the obvious muscle-memorised place to look at.

-----

By the way, a curated `CONTRIBUTING.md` could replace the mess on the Wiki as a single source of truth.