### PR TITLE
Fix bootstrap arguments

### DIFF
--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -12,7 +12,7 @@ ECHO Building Boost.Build engine
 if exist ".\tools\build\src\engine\b2.exe" del tools\build\src\engine\b2.exe
 pushd tools\build\src\engine
 
-call .\build.bat
+call .\build.bat %1
 @ECHO OFF
 
 popd


### PR DESCRIPTION
Now user can specify compiler just by typing "bootstrap.bat gcc" or something that match to his compiler. First command-line argument will be passed to build.bat.