### PR TITLE
Rename mips1 to mips

### DIFF
--- a/boostcpp.jam
+++ b/boostcpp.jam
@@ -634,7 +634,7 @@ rule address-model ( )
     return <conditional>@boostcpp.deduce-address-model ;
 }
 
-local deducable-architectures = arm mips1 power riscv s390x sparc x86 combined ;
+local deducable-architectures = arm mips power riscv s390x sparc x86 combined ;
 feature.feature deduced-architecture : $(deducable-architectures) : propagated optional composite hidden ;
 for a in $(deducable-architectures)
 {
@@ -645,10 +645,10 @@ rule deduce-architecture ( properties * )
 {
     local result ;
     local filtered = [ toolset-properties $(properties) ] ;
-    local names = arm mips1 power riscv s390x sparc x86 combined ;
+    local names = arm mips power riscv s390x sparc x86 combined ;
     local idx = [ configure.find-builds "default architecture" : $(filtered)
         : /boost/architecture//arm
-        : /boost/architecture//mips1
+        : /boost/architecture//mips
         : /boost/architecture//power
         : /boost/architecture//riscv
         : /boost/architecture//s390x


### PR DESCRIPTION
In fact mips1 is now used for all mips revisions.