### PR TITLE
Add support for LoongArch

### DIFF
--- a/boostcpp.jam
+++ b/boostcpp.jam
@@ -634,7 +634,7 @@ rule address-model ( )
     return <conditional>@boostcpp.deduce-address-model ;
 }
 
-local deducable-architectures = arm mips1 power riscv s390x sparc x86 combined ;
+local deducable-architectures = arm loongarch mips1 power riscv s390x sparc x86 combined ;
 feature.feature deduced-architecture : $(deducable-architectures) : propagated optional composite hidden ;
 for a in $(deducable-architectures)
 {
@@ -645,9 +645,10 @@ rule deduce-architecture ( properties * )
 {
     local result ;
     local filtered = [ toolset-properties $(properties) ] ;
-    local names = arm mips1 power riscv s390x sparc x86 combined ;
+    local names = arm loongarch mips1 power riscv s390x sparc x86 combined ;
     local idx = [ configure.find-builds "default architecture" : $(filtered)
         : /boost/architecture//arm
+        : /boost/architecture//loongarch
         : /boost/architecture//mips1
         : /boost/architecture//power
         : /boost/architecture//riscv


### PR DESCRIPTION
Add support for LoongArch, please review, thanks!
Boost related sub modules have been submitted ,  and I have completed the relevant tests on PC.

```
Test result:
1) libs/context/test:
cc1plus: error: ‘-fsplit-stack’ is not supported by this compiler configuration （ It's can be ignored）
2) libs/fiber/test : all pass
3) libs/predef/test: all pass
4) libs/config/test:  all pass
```