### PR TITLE
CircleCI snapshots - add CRLF

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,5 +10,7 @@ jobs:
       - run: wget "https://raw.githubusercontent.com/boostorg/release-tools/python3/ci_boost_release.py" -P ${HOME}
       - run: python3 ${HOME}/ci_boost_release.py checkout_post
       # - run: python3 ${HOME}/ci_boost_release.py dependencies_override
+      - run: '[ "$CIRCLE_NODE_INDEX" != "0" ] || EOL=LF python3 ${HOME}/ci_boost_release.py test_pre'
+      - run: '[ "$CIRCLE_NODE_INDEX" != "1" ] || EOL=CRLF python3 ${HOME}/ci_boost_release.py test_pre'
       - run: '[ "$CIRCLE_NODE_INDEX" != "0" ] || EOL=LF python3 ${HOME}/ci_boost_release.py test_override'
       - run: '[ "$CIRCLE_NODE_INDEX" != "1" ] || EOL=CRLF python3 ${HOME}/ci_boost_release.py test_override'


### PR DESCRIPTION
In this [release-tools issue](https://github.com/boostorg/release-tools/issues/32) a user reports the  .zip and .7z packages should use Windows line endings.  

Before the problem appeared in 2019 the CI scripts would execute the "test_pre", "test_override" and "test_post" methods. Lately, only "test_override" runs.   "test_pre" was where line endings were set.     


