### PR TITLE
Fix building Boost.Build with a chosen toolset

### DIFF
--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -12,7 +12,7 @@ ECHO Building Boost.Build engine
 if exist ".\tools\build\src\engine\b2.exe" del tools\build\src\engine\b2.exe
 pushd tools\build\src\engine
 
-call .\build.bat
+call .\build.bat %1
 @ECHO OFF
 
 popd


### PR DESCRIPTION
👋 

Hi! This PR proposes to upstream a small change that we are shipping in Krita starting with 5.1 (https://invent.kde.org/graphics/krita/-/commit/2876937bf2dfea45645c31ebb749b1a0d08d067b).

In short, this will enable users of the CMD bootstrap file to build Boost with a toolset other than MSVC. We use it in particular to target the llvm-mingw compiler, through a custom user-config.jam. (It also applies to the official MSYS2 CLANG* flavours, which I use for my own personal development needs.)

cc @dimula73