### PR TITLE
Changed const reference to non-const reference to fix Boost.Serializa…

### DIFF
--- a/index1.html
+++ b/index1.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta http-equiv="refresh" content="0; URL=index.html" />
+
+  <title></title>
+  <link rel="stylesheet" href="doc/src/boostbook.css" type="text/css" />
+</head>
+
+<body>
+  Automatic redirection failed, please go to <a href=
+  "index.html">index.html</a>.
+
+  <div class="copyright-footer">
+    <p>Copyright 2008 Rene Rivera</p>
+
+    <p>Distributed under the Boost Software License, Version 1.0. (See
+    accompanying file <a href="LICENSE_1_0.txt">LICENSE_1_0.txt</a> or copy
+    at <a href=
+    "http://www.boost.org/LICENSE_1_0.txt">http://www.boost.org/LICENSE_1_0.txt</a>)</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
// Added BOOST_CLASS_EXPORT macro to register polymorphic class with Boost.Serialization
class BOOST_SYMBOL_VISIBLE MyPolymorphicClass : public MyBaseClass
{
    // Class definition here
};
BOOST_CLASS_EXPORT(MyPolymorphicClass)
