### PR TITLE
CircleCI: update image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cppalliance/boost_superproject_build:20.04-v1
+      - image: cppalliance/boost_superproject_build:20.04-v2
     parallelism: 2
     steps:
       - checkout


### PR DESCRIPTION
Add `rclone` and `aws cli` packages to the image, when building a release.  