### PR TITLE
CircleCI Docker image supports antora builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cppalliance/boost_superproject_build:20.04-v2
+      - image: cppalliance/boost_superproject_build:20.04-v3
     parallelism: 2
     steps:
       - checkout


### PR DESCRIPTION
Updates CircleCI Docker image to `cppalliance/boost_superproject_build:20.04-v3`, which includes nodejs.