### PR TITLE
CircleCI: autocancel workflows

### DIFF
--- a/.circleci/autocancel.sh
+++ b/.circleci/autocancel.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Auto-cancel preceding workflows
+# https://discuss.circleci.com/t/workaround-auto-cancel-redundant-builds-on-the-default-branch/39468
+
+set -x
+
+## Get the name of the workflow and the related pipeline number
+curl --header "Circle-Token: $PERS_API_TOKEN_BOOST_5" --request GET "https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}" -o current_workflow.json
+WF_NAME=$(jq -r '.name' current_workflow.json)
+CURRENT_PIPELINE_NUM=$(jq -r '.pipeline_number' current_workflow.json)
+CURRENT_PIPELINE_CREATED=$(jq -r '.created_at' current_workflow.json)
+TIME_THRESHOLD=$(date --utc +'%Y-%m-%dT%TZ' -d "${CURRENT_PIPELINE_CREATED} -10 minutes")
+
+## Get the IDs of pipelines created by the current user on the same branch. (Only consider pipelines that have a pipeline number inferior to the current pipeline)
+PIPE_IDS=$(curl --header "Circle-Token: $PERS_API_TOKEN_BOOST_5" --request GET "https://circleci.com/api/v2/project/gh/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pipeline?branch=$CIRCLE_BRANCH"|jq -r --argjson CURRENT_PIPELINE_NUM "$CURRENT_PIPELINE_NUM" --arg TIME_THRESHOLD "${TIME_THRESHOLD}" '.items[] | select(.state == "created") | select(.number < $CURRENT_PIPELINE_NUM) | select(.created_at > $TIME_THRESHOLD) | .id')
+
+## Get the IDs of currently running/on_hold workflows that have the same name as the current workflow, in all previously created pipelines.
+if [ ! -z "$PIPE_IDS" ]; then
+  for PIPE_ID in $PIPE_IDS
+  do
+    curl --header "Circle-Token: $PERS_API_TOKEN_BOOST_5" --request GET "https://circleci.com/api/v2/pipeline/${PIPE_ID}/workflow"|jq -r --arg WF_NAME "${WF_NAME}" '.items[]|select(.status == "on_hold" or .status == "running") | select(.name == $WF_NAME) | .id' >> WF_to_cancel.txt
+  done
+fi
+
+## Cancel any currently running/on_hold workflow with the same name
+if [ -s WF_to_cancel.txt ]; then
+  echo "Cancelling the following workflow(s):"
+  cat WF_to_cancel.txt
+  while read WF_ID;
+    do
+      curl --header "Circle-Token: $PERS_API_TOKEN_BOOST_5" --request POST https://circleci.com/api/v2/workflow/$WF_ID/cancel
+    done < WF_to_cancel.txt
+  ## Allowing some time to complete the cancellation
+  sleep 2
+  else
+    echo "Nothing to cancel"
+fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,12 @@
-version: 2
+version: 2.1
 jobs:
   build:
     docker:
-      - image: cppalliance/boost_superproject_build:20.04-v4
+      - image: cppalliance/boost_superproject_build:22.04-v1
     parallelism: 2
     steps:
       - checkout
+      - run: ./.circleci/autocancel.sh || true
       - run: wget "https://raw.githubusercontent.com/boostorg/release-tools/develop/ci_boost_common.py" -P ${HOME}
       - run: wget "https://raw.githubusercontent.com/boostorg/release-tools/develop/ci_boost_release.py" -P ${HOME}
       - run: python3 ${HOME}/ci_boost_release.py checkout_post


### PR DESCRIPTION
Note: create an API token before proceeding.

To prevent a problem with multiple commits occurring at nearly the same time and overwriting snapshots, there are two solutions:  

1. Force sequential builds. However, a difficulty is that each build takes 45 minutes, so when 10 commits happen in sequence the final snapshot won't be ready for 7 hours.

or

2. Cancel previous in-progress builds. Only the newest commit is relevant when building a snapshot. This generally seems preferable since it's faster. A small disadvantage is that if one commit out of ten caused an error, it won't be immediately obvious which commit caused the error.  Not often an issue.

This PR cancels in-progress builds. As an enhancement, it checks the time, and only cancels other jobs from within the last 10 minutes. Any job that's been running longer will be unlikely to conflict.

Token

1. Create a Personal API Token https://app.circleci.com/settings/user/tokens (any token name)
2. In the Project, add an Environment Variable https://app.circleci.com/settings/project/github/boostorg/boost/environment-variables
Name: PERS_API_TOKEN_BOOST_5   (this name must match the script autocancel.sh)
Value: the token from step 1

