### PR TITLE
unified implict feature for platform deduction

### DIFF
--- a/Jamroot
+++ b/Jamroot
@@ -172,8 +172,7 @@ if $(all-headers)
 project boost
     : requirements <include>.
 
-      [ boostcpp.architecture ]
-      [ boostcpp.address-model ]
+      [ boostcpp.platform ]
 
       # Disable auto-linking for all targets here, primarily because it caused
       # troubles with V2.

--- a/boostcpp.jam
+++ b/boostcpp.jam
@@ -606,32 +606,38 @@ rule toolset-properties ( properties * )
     return [ property.select <target-os> <toolset> $(toolset-version-property) : $(properties) ] ;
 }
 
-rule deduce-address-model ( properties * )
+.deducible-architectures = arm loongarch mips power riscv s390x sparc x86 combined ;
+feature.feature x-deduced-platform
+    : $(.deducible-architectures)_32 $(.deducible-architectures)_64
+    : composite implicit optional propagated ;
+for a in $(.deducible-architectures)
 {
-    local deduced ;
+    feature.compose <x-deduced-platform>$(a)_32 : <architecture>$(a) <address-model>32 ;
+    feature.compose <x-deduced-platform>$(a)_64 : <architecture>$(a) <address-model>64 ;
+}
+
+rule deduce-platform ( properties * )
+{
+    local deduced-pl = [ property.select <x-deduced-platform> : $(properties) ] ;
+    if $(deduced-pl)
+    {
+        return $(deduced-pl) ;
+    }
+
     local filtered = [ toolset-properties $(properties) ] ;
+
     local names = 32 64 ;
     local idx = [ configure.find-builds "default address-model" : $(filtered)
         : /boost/architecture//32 "32-bit"
         : /boost/architecture//64 "64-bit" ] ;
-    deduced = $(names[$(idx)]) ;
+    local deduced-am = $(names[$(idx)]) ;
+    if ! $(deduced-am)
+    {
+        return ;
+    }
 
-    local result = [ property.select <address-model> : $(properties) ] ;
-    result ?= <address-model>$(deduced) ;
-    return $(result) ;
-}
-
-rule address-model ( )
-{
-    return <conditional>@boostcpp.deduce-address-model ;
-}
-
-rule deduce-architecture ( properties * )
-{
-    local deduced ;
-    local filtered = [ toolset-properties $(properties) ] ;
-    local names = arm loongarch mips power riscv s390x sparc x86 combined ;
-    local idx = [ configure.find-builds "default architecture" : $(filtered)
+    names = $(.deducible-architectures) ;
+    idx = [ configure.find-builds "default architecture" : $(filtered)
         : /boost/architecture//arm
         : /boost/architecture//loongarch
         : /boost/architecture//mips
@@ -641,14 +647,29 @@ rule deduce-architecture ( properties * )
         : /boost/architecture//sparc
         : /boost/architecture//x86
         : /boost/architecture//combined ] ;
-    deduced = $(names[$(idx)]) ;
+    local deduced-arch = $(names[$(idx)]) ;
+    if ! $(deduced-arch)
+    {
+        return ;
+    }
 
-    local result = [ property.select <architecture> : $(properties) ] ;
-    result ?= <architecture>$(deduced) ;
-    return $(result) ;
+    local requested-am = [ property.select <address-model> : $(properties) ] ;
+    requested-am ?= <address-model>$(deduced-am) ;
+
+    local requested-arch = [ property.select <architecture> : $(properties) ] ;
+    requested-arch ?= <architecture>$(deduced-arch) ;
+
+    deduced-pl = $(requested-arch:G=<x-deduced-platform>)_$(requested-am:G=) ;
+
+    if ! $(deduced-pl:G=) in [ feature.values <x-deduced-platform> ]
+    {
+        deduced-pl = ;
+    }
+    return $(deduced-pl) ;
 }
 
-rule architecture ( )
+
+rule platform ( )
 {
-    return <conditional>@boostcpp.deduce-architecture ;
+    return <conditional>@boostcpp.deduce-platform ;
 }


### PR DESCRIPTION
This changes separate deduction of `address-model` and `architecture` with a single `x-deduced-platform` (the corresponding rule is `platform`. The purpose of this is to shorten the target path, while keeping it unique for different configurations.

The logic of the conditional rule is this:
1. If there's already `x-deduced-platform` in the property set, then return that (this is needed for repeated evaluation of conditionals).
2. If eihter `address-model` or `architecture` could not be deduced, return nothing.
3. Get  `address-model` and `architecture` properties from the property set, assign deduced values to any if it is empty.
4. Construct the corresponding value of `x-deduced-platform`. If there's no corresponfing value (e.g. user requested an architecture we don't support for deduction), return nothing.
5. Otherwise return the constructed value.

The feature `x-deduced-platform` is composite. Due to that it subsumes properties that constitute it. Meaning, `<address-model>32 <x-deduced-platform>x86` corresponds to the path `x86` and not `x86/address-model-32`. Which is pretty neat.

The `x-` in the name `x-deduced-platform` is so that it sorts last.