### PR TITLE
guard tag against empty type

### DIFF
--- a/boostcpp.jam
+++ b/boostcpp.jam
@@ -185,7 +185,7 @@ else
 
 rule tag ( name : type ? : property-set )
 {
-    if $(type) in STATIC_LIB SHARED_LIB IMPORT_LIB
+    if $(type:E=x) in STATIC_LIB SHARED_LIB IMPORT_LIB
     {
         local args = $(.format-name-args) ;
         if $(layout) = versioned


### PR DESCRIPTION
In b2 `$(a) in A B C` is true when `$(a)` is empty (empty set is a subset of any set). So, the tag will produce a result for untyped targets, which is clearly not intended.

This currently does not happen anyway, because b2 doesn't run `<tag>`s for untyped targets, but I intend to change that, so that users could do `make a : : @make-rule : <tag>@tag-rule ;`