### PR TITLE
Update links to BoostBook documentation

### DIFF
--- a/doc/html/boostbook.html
+++ b/doc/html/boostbook.html
@@ -7,10 +7,10 @@
       (See accompanying file LICENSE_1_0.txt or copy at
       http://www.boost.org/LICENSE_1_0.txt) -->
     <title>Redirect to generated documentation</title>
-    <meta http-equiv="refresh" content="0; URL=http://www.boost.org/doc/libs/master/doc/html/boostbook.html">
+    <meta http-equiv="refresh" content="0; URL=../../tools/boostbook/index.html">
   </head>
   <body>
     Automatic redirection failed, please go to
-    <a href="http://www.boost.org/doc/libs/master/doc/html/boostbook.html">http://www.boost.org/doc/libs/master/doc/html/boostbook.html</a>
+    <a href="../../tools/boostbook/index.html">../../tools/boostbook/index.html</a>
   </body>
 </html>

--- a/tools/index.html
+++ b/tools/index.html
@@ -59,7 +59,7 @@
             errors in the Boost directory hierarchy.<br>
          &nbsp;
          <li>
-            <a href="../doc/html/boostbook.html">BoostBook</a> - A Boost documentation 
+            <a href="boostbook/index.html">BoostBook</a> - A Boost documentation 
             system, based on <a href="http://www.docbook.org/">DocBook</a> and the <a href="http://www.w3.org/Style/XSL/">
                Extensible Stylesheet Language (XSL)</a>, used by some Boost libraries.<br>
          &nbsp;


### PR DESCRIPTION
The documentation is built at tools/boostbook/doc/html, and tools/boostbook/index.html contains a universal redirect to the actual location of the docs entry point.

This also resolves the circular redirect in doc/html/boostbook.html.

Refs https://github.com/boostorg/boost/issues/937.