### PR TITLE
Revert "CircleCI: update image"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: cppalliance/boost_superproject_build:24.04-v1
+      - image: cppalliance/boost_superproject_build:22.04-v1
     parallelism: 2
     steps:
       - checkout


### PR DESCRIPTION
Reverts boostorg/boost#941

Because of

```
# /root> '7z' 'a' '-bd' '-mx=7' '-ms=on' '-x!boost_1_87_0/ci_boost_common.py' '-x!boost_1_87_0/ci_boost_release.py' 'boost_1_87_0-snapshot.7z' 'boost_1_87_0'
*** buffer overflow detected ***: terminated
```