### PR TITLE
CircleCI: 24.04 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: cppalliance/boost_superproject_build:22.04-v1
+      - image: cppalliance/boost_superproject_build:24.04-v1
     parallelism: 2
     steps:
       - checkout


### PR DESCRIPTION
The newer image is already in place on the `develop` branch.

cc. @pdimov 