### PR TITLE
Commitbot features

### DIFF
--- a/.github/workflows/commit-bot.yml
+++ b/.github/workflows/commit-bot.yml
@@ -8,7 +8,7 @@ name: Commit Bot
 #   "If an action pushes code using the repository's GITHUB_TOKEN, a new workflow will not run"
 #
 # - Processing of either the 'master' or 'develop' branch may be stopped by creating the variables
-#   vars.block_master or vars.block_develop with any value.
+#   vars.block_master or vars.block_develop with the value "yes".
 #   https://github.com/boostorg/boost/settings/variables/actions
 #
 
@@ -34,19 +34,19 @@ jobs:
             set -xe
             branches=""
             if [[ "${{ github.event_name }}" == "push" ]]; then
-                if [[ ! -n "${{ vars.block_master }}" && "${{ github.ref_name }}" == "master" ]]; then
+                if [[ ! "${{ vars.block_master }}" == "yes" && "${{ github.ref_name }}" == "master" ]]; then
                     branches="master"
-                elif [[ ! -n "${{ vars.block_develop }}" && "${{ github.ref_name }}" == "develop" ]]; then
+                elif [[ ! "${{ vars.block_develop }}" == "yes" && "${{ github.ref_name }}" == "develop" ]]; then
                     branches="develop"
                 else
                     branches="${{ github.ref_name }}"
                 fi
             else
                 # from a schedule:
-                if [[ ! -n "${{ vars.block_master }}" ]]; then
+                if [[ ! "${{ vars.block_master }}" == "yes" ]]; then
                     branches="master"
                 fi
-                if [[ ! -n "${{ vars.block_develop }}" ]]; then
+                if [[ ! "${{ vars.block_develop }}" == "yes" ]]; then
                     branches="${branches} develop"
                 fi
             fi


### PR DESCRIPTION
Modifies the commit-bot so the variables `block_develop` and `block_master` require the value of "yes" .  

@mclow  merge this when you like.   

How about delaying until after boost 1.87.0 has been released, and after the bot has been re-enabled.   

For this cycle, completely remove the variable `block_master`.  Next time it can merely be set to "no".
