### PR TITLE
manual installation of boost for linux

### DIFF
--- a/boost-linux-manual-install-1_87_0.sh
+++ b/boost-linux-manual-install-1_87_0.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#no hash verification
+sudo apt update && apt full-upgrade -y && sudo apt install g++-14 curl grep gzip tar wget
+
+wget https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.gz
+gunzip boost_1_87_0.tar.gz && tar -xf boost_1_87_0.tar
+sudo cp boost_1_87_0/boost /usr/include/ -r
+rm boost_1_87_0 boost_1_87_0.tar -r -f
+


### PR DESCRIPTION
It work well with ubuntu 24
hash verification is not implemented in the file