### PR TITLE
Updated Deprecated build submodule within in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -305,7 +305,7 @@
 	branch = .
 [submodule "build"]
 	path = tools/build
-	url = ../build.git
+	url = https://github.com/bfgroup/b2.git
 	fetchRecurseSubmodules = on-demand
 	branch = .
 [submodule "quickbook"]


### PR DESCRIPTION
I stumbled upon this issue while building a project that uses the boost library as submodule.

Issue being faced while building is very similar to: https://github.com/bfgroup/b2/issues/323#issuecomment-1592899069

The build submodule repository seems to be shifted but the `.submodule ` has not been updated , resulting in build failing for the project i'm trying to build ( [Organic Maps](https://github.com/organicmaps/organicmaps/tree/master)) which uses the boost library as a submodule. 


The build submodule Repository https://github.com/boostorg/build  seems to have moved to https://github.com/boostorg/build
Reference : https://github.com/boostorg/build/issues/614#issuecomment-850859613

NOTE:  This is my first attempt at a open source PR , Kindly forgive if there is a mistake on my part .
