### PR TITLE
test build with Intel oneAPI (icpx)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,39 @@ jobs:
           cd __build__
           cmake --build . -j 3 --target install
 
+  cmake-install-intel:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - container: intel/oneapi-hpckit:2025.0.2-0-devel-ubuntu24.04
+          - container: intel/oneapi-hpckit:2024.0.1-devel-ubuntu22.04
+
+    container:
+      image: ${{matrix.container}}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Configure Boost
+        run: |
+          mkdir __build__ && cd __build__
+          cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_CXX_COMPILER=icpx ..
+
+      - name: Build Boost
+        run: |
+          cd __build__
+          cmake --build . -j 3
+
+      - name: Install Boost
+        run: |
+          cd __build__
+          cmake --build . -j 3 --target install
+
   cmake-test-posix:
     strategy:
       fail-fast: false


### PR DESCRIPTION
The Intel compiler suite is often used on clusters. Since the re-branding to "oneAPI", it is available at no cost and Intel offers containers on DockerHub. This allows easy integration into GitHub actions.

This PR ensures that the Boost libraries can at least be build with CMake. Further enhancements could include
- building with b2
- running the test suite

Currently, the test suite fails. Hence, probably fixes (and, ideally enhancements to the CI) for some of the subpackages are needed first.


see #952 and #615