### PR TITLE
Simplify for modular building.

### DIFF
--- a/tools/Jamfile.v2
+++ b/tools/Jamfile.v2
@@ -1,55 +1,24 @@
-# Copyright 2005 Rene Rivera 
-# Copyright 2005 Hartmut Kaiser 
-# Copyright 2005 John Maddock 
-# Copyright 2003 Vladimir Prus 
-# Distributed under the Boost Software License, Version 1.0. 
-# (See accompanying file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt) 
+# Copyright 2005,2024 René Ferdinand Rivera Morell
+# Copyright 2005 Hartmut Kaiser
+# Copyright 2005 John Maddock
+# Copyright 2003 Vladimir Prus
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
 
 
-# Jamfile which builds all the tools.
+# Jamfile which builds or installs all the tools.
 
-project 
+alias dist
+    :   auto_index//dist
+        bcp//dist
+        boost_install//dist
+        boostbook//dist
+        boostdep//dist
+        inspect//dist
+        quickbook//dist
     :
-    requirements
-    <link>static
-    <implicit-dependency>/boost//headers 
-    : 
-    usage-requirements <implicit-dependency>/boost//headers 
-    ;
-
-TOOLS =
-    bcp//bcp
-    inspect/build//inspect
-    quickbook//quickbook
-    /boost/libs/wave/tool//wave
-    ;
-
-install dist-bin
-    :
-    $(TOOLS)
-    :
-    <install-type>EXE
-    <location>../dist/bin
-    :
-    release
-    ;
-
-install dist-lib
-    :
-    $(TOOLS)
-    :
-    <install-type>LIB
-    <location>../dist/lib
-    :
-    release
-    ;
-
-local patterns = *.dtd *.xml *.xsl LICENSE ;
-local dirs = boostbook/dtd boostbook/xsl ;
-install dist-share-boostbook
-    :
-    [ glob $(dirs)/$(patterns) $(dirs)/*/$(patterns) $(dirs)/*/*/$(patterns) ]
-    :
-    <location>../dist/share
-    <install-source-root>.
+    :   # default-build
+        release
+        <link>static
+        <cxxstd>11
     ;


### PR DESCRIPTION
Modular building delegates, and normalizes, the building of tools inside the tools themselves. This makes it possible to avoid a bunch of code at this level. This change also adds default building for all current tools.