### PR TITLE
Remove Ubuntu 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
           - os: ubuntu-22.04
           - os: ubuntu-22.04-arm
           - os: ubuntu-24.04
@@ -90,7 +89,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
           - os: ubuntu-22.04
           - os: ubuntu-22.04-arm
           - os: ubuntu-24.04
@@ -187,7 +185,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
           - os: ubuntu-22.04
           - os: ubuntu-22.04-arm
           - os: ubuntu-24.04


### PR DESCRIPTION
GitHub/Microsoft no longer provides ubuntu-20.04 testing.