### PR TITLE
Update release-cmake.yml

### DIFF
--- a/.github/workflows/release-cmake.yml
+++ b/.github/workflows/release-cmake.yml
@@ -29,6 +29,7 @@ jobs:
 
       - uses: softprops/action-gh-release@v2
         with:
+          make_latest: ${{ contains(github.ref_name, '.beta') && 'false' || 'true' }}
           files: |
             ${{ github.ref_name }}-cmake.tar.gz
             ${{ github.ref_name }}-cmake.tar.gz.txt
@@ -61,6 +62,7 @@ jobs:
 
       - uses: softprops/action-gh-release@v2
         with:
+          make_latest: ${{ contains(github.ref_name, '.beta') && 'false' || 'true' }}
           files: |
             ${{ github.ref_name }}-cmake.zip
             ${{ github.ref_name }}-cmake.zip.txt
@@ -101,6 +103,7 @@ jobs:
 
       - uses: softprops/action-gh-release@v2
         with:
+          make_latest: ${{ contains(github.ref_name, '.beta') && 'false' || 'true' }}
           files: |
             ${{ github.ref_name }}-b2-nodocs.tar.gz
             ${{ github.ref_name }}-b2-nodocs.tar.gz.txt
@@ -142,6 +145,7 @@ jobs:
 
       - uses: softprops/action-gh-release@v2
         with:
+          make_latest: ${{ contains(github.ref_name, '.beta') && 'false' || 'true' }}
           files: |
             ${{ github.ref_name }}-b2-nodocs.zip
             ${{ github.ref_name }}-b2-nodocs.zip.txt


### PR DESCRIPTION
do not make beta releases latest releases. As you don't specify `make_latest` it defaults to github api defaults, which make any new release latest.

https://github.com/softprops/action-gh-release?tab=readme-ov-file#inputs

This will set it to true for non beta releases and false for beta releases.

here is an example run

https://github.com/userdocs/test/releases

<img width="1246" height="875" alt="image" src="https://github.com/user-attachments/assets/29d0415f-5315-4a0a-ac02-ff2bb21f0183" />

<img width="1267" height="1023" alt="image" src="https://github.com/user-attachments/assets/42d93222-8953-4e6a-9833-1ab3b1d60547" />

