### PR TITLE
Boost cmake build requires CMake 3.19 or above

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Distributed under the Boost Software License, Version 1.0.
 # See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
 
-cmake_minimum_required(VERSION 3.5...3.16)
+cmake_minimum_required(VERSION 3.19)
 
 # The default build type must be set before project()
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR AND NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)


### PR DESCRIPTION
I've been poking around with the cmake build of boost.
See also [boostorg/nowide#199](https://github.com/boostorg/nowide/pull/199) and [boostorg/parser#277](https://github.com/boostorg/parser/issues/277)

What I'm finding on Ubuntu 24.04 is that boost requires [cmake 3.19](https://cmake.org/cmake/help/latest/release/3.19.html) or newer.
Various things break with [cmake 3.18](https://cmake.org/cmake/help/latest/release/3.18.html) in my experiments.

It seems possible that work could be done in various libraries to support older versions of cmake.
But it's not clear that work would be tidy, maintainable or valuable in a widespread sense.

So the proposal here is that boost simply _requires_ cmake 3.19 and fails early and clearly otherwise.

```
$ PATH=/opt/cmake-3.18.0-Linux-x86_64/bin:$PATH cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=N && ninjaCMake Error at CMakeLists.txt:5 (cmake_minimum_required):
  CMake 3.19 or higher is required.  You are running version 3.18.0


-- Configuring incomplete, errors occurred!
```

I think this change would also be helpful in terms of library maintainers having some clarity about what version of cmake they can assume.   Policy [prior to cmake 3.10](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#policy-version) was deprecated in cmake 3.31 and policy [prior to cmake 3.5](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#policy-version) was removed.

So it seems that cmake 3.10 is _the_ _most_ we could reasonably try to support for boost, but cmake 3.19 is where boost is at currently, in practice. 