### PR TITLE
CMake: Show used CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,13 @@
 cmake_minimum_required(VERSION 3.5...3.16)
 
 # The default build type must be set before project()
-if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR AND NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-  set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
-  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  message(STATUS "Using CMake ${CMAKE_VERSION}")
+
+  if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+  endif()
 endif()
 
 project(Boost VERSION 1.90.0 LANGUAGES CXX)


### PR DESCRIPTION
In super-builds show the CMake version which is especially useful on CI to verify the used CMake and/or compare different jobs on failure.

Limited to the super build to not be too verbose when Boost is used via `add_subdirectory` or similar.