### PR TITLE
Update required CMake version to 3.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Distributed under the Boost Software License, Version 1.0.
 # See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
 
-cmake_minimum_required(VERSION 3.5...3.16)
+cmake_minimum_required(VERSION 3.8...3.16)
 
 # The default build type must be set before project()
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR AND NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)


### PR DESCRIPTION
Most libraries are C++11 and require CMake 3.8 for the CMake feature or depend on libraries that do.
Drop support for earlier CMake versions in the super project to reduce the number of versions to verify.

This comes from my experiments in the tools/cmake repo testing a range of CMake versions.

The list of libraries not supporting CMake < 3.8 keeps on growing so I'd say it doesn't make sense anymore to support that going forward. I'm currently at over 60 libraries that require CMake 3.8, there are others (around a dozen or so) that require even higher versions.

(Incomplete) list of libraries incompatible with CMake 3.7:
> outcome;asio;atomic;beast;bind;bloom;callable_traits;charconv;chrono;compat;container_hash;contract;crc;date_time;endian;fiber;filesystem;format;function;geometry;gil;graph;hana;hash2;heap;hof;iostreams;json;lambda2;lockfree;log;mqtt5;mysql;numeric/ublas;process;program_options;property_tree;random;ratio;redis;safe_numerics;serialization;smart_ptr;static_string;stl_interfaces;system;test;thread;type_erasure;typeof;unordered;url;uuid;variant2;wave;yap;hana;nowide;gil;sort;locale;cobalt;histogram;msm;parser;python;pfr;mysql

What do you say @pdimov ?