### PR TITLE
CircleCI increase resource_class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 jobs:
   build:
+    resource_class: large
     docker:
       - image: cppalliance/boost_superproject_build:24.04-v4
     parallelism: 2


### PR DESCRIPTION
The job time is approaching 60 minutes and causing a timeout. There are multiple options:
- switch to performance plan, 3 hour limit.  
- increase resource_class (which will consume credits at a faster rate).  

CircleCI starts at $15/month, it's not a blocker, if needed.  

I have not tested this change "resource_class: large" let's try it on the `develop` branch.    It may turn out 'large' is not permitted here.  

@pdimov 

