### PR TITLE
Allow passing `--cxx` and `--cxxflags` to `bootstrap.sh`

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -365,7 +365,7 @@ import feature ;
 
 EOF
 if test "x$TOOLSET" != x; then
-  cat > project-config.jam <<EOF
+  cat >> project-config.jam <<EOF
   # Compiler configuration. This definition will be used unless
   # you already have defined some toolsets in your user-config.jam
   # file.


### PR DESCRIPTION
This allows selecting a specific compiler for building if e.g. `g++` is not available but only `g++-15`.

As `$TOOLSET` isn't set in this case, unless passed by the user, that part of the project-config needs to be omitted. The alternative is to use "cxx" as what `build.sh` does but that might also not be what the user wanted.