### PR TITLE
CircleCI increase resource_class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 jobs:
   build:
+    resource_class: large
     docker:
       - image: cppalliance/boost_superproject_build:24.04-v4
     parallelism: 2


### PR DESCRIPTION
In the `develop` branch,  resource_class seemed to have very little effect. This change also might not solve the problem.   If `master` continues to time out let's chat about upgrading the Circle account.    @pdimov   