### PR TITLE
fix Predef install

### DIFF
--- a/boostcpp.jam
+++ b/boostcpp.jam
@@ -591,6 +591,11 @@ rule libraries-to-install ( existing-libs * )
 
 rule declare-targets ( all-libraries * )
 {
+    if ! predef in $(all-libraries)
+    {
+        all-libraries += predef ;
+    }
+
     configure.register-components $(all-libraries) ;
 
     # Select the libraries to install.


### PR DESCRIPTION
Fix #1137.

Predef installs b2 modules, so we have to consider it a compiled library. A proper fix requires more structural changes.