### PR TITLE
fix installing CMake configs

### DIFF
--- a/Jamroot
+++ b/Jamroot
@@ -406,7 +406,8 @@ rule boost-lib ( name : sources * : requirements * : default-build * : usage-req
 
 # Declare special top-level targets that build and install the desired variants
 # of the libraries.
-boostcpp.declare-targets $(all-libraries-to-build) ;
+boostcpp.declare-targets $(all-libraries-modular-build) :
+    $(all-libraries-to-build) ;
 
 # Declare a Boost library and run related declaration rules. This should be
 # called from the libroot/build.jam to define the components of a Boost lib.

--- a/boostcpp.jam
+++ b/boostcpp.jam
@@ -589,37 +589,28 @@ rule libraries-to-install ( existing-libs * )
     }
 }
 
-rule declare-targets ( all-libraries * )
+rule declare-targets ( modular-libraries * : compiled-libraries * )
 {
-    if ! predef in $(all-libraries)
-    {
-        all-libraries += predef ;
-    }
-
-    configure.register-components $(all-libraries) ;
+    configure.register-components $(compiled-libraries) ;
 
     # Select the libraries to install.
-    libraries = [ libraries-to-install $(all-libraries) ] ;
-    configure.components-building $(libraries) ;
+    local filtered = [ libraries-to-install $(compiled-libraries) ] ;
+    configure.components-building $(filtered) ;
 
     if [ option.get "show-libraries" : : true ]
     {
         ECHO The following libraries require building\: ;
-        for local l in $(libraries)
+        for local l in $(filtered)
         {
-            if $(l) = function_types
-            {
-                continue ;
-            }
-            if [ path.glob $(BOOST_ROOT)/libs/$(l)/build : Jamfile Jamfile.v2 ]
-            {
-                echo "    - $(l)" ;
-            }
+            echo "    - $(l)" ;
         }
         EXIT ;
     }
 
-    declare_top_level_targets $(libraries) ;
+    local header-only-modular = [ set.difference $(modular-libraries) :
+        $(compiled-libraries) ] ;
+
+    declare_top_level_targets $(filtered) $(header-only-modular) ;
 }
 
 # Returns the properties identifying the toolset. We'll use them


### PR DESCRIPTION
Fix #1137.

This makes it so that only compiled libraries are listed (and can be disabled with `--without-`). But header-only _modularised_ libraries are still installed (with their associated files).